### PR TITLE
docs: record near-term scope and correct domain glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,9 +110,8 @@ Positive TSB means rested; negative means under load. _Avoid_: Form score,
 freshness
 
 **Load Snapshot**: A single athlete's training load values for a single calendar
-day in the athlete's local timezone (daily TSS totals, CTL, ATL, TSB).
-Materialized by a background job, never computed on-the-fly. _Avoid_: Daily
-load, load row
+day in the athlete's local timezone (daily TSS totals, CTL, ATL, TSB). _Avoid_:
+Daily load, load row
 
 **Load Formula**: The named method used to compute TSS for one session — one of
 `coggan` (power-based), `hrTSS` (heart-rate-based), `rTSS` (pace-based run),
@@ -154,11 +153,11 @@ _Avoid_: Creator, participant
 
 ### App structure
 
-**The Tape**: The primary navigation primitive — a single horizontal scrubbable
-timeline of Workout Sessions, past on the left, planned on the right, "Now"
-centered. The Dashboard, Upcoming Ledger, and Workout Detail View are different
-zoom levels of the Tape, not separate surfaces. _Avoid_: Calendar, grid,
-dashboard-as-feature
+**The Tape**: A long-term idea for a single horizontal scrubbable timeline of
+Workout Sessions (past left, planned right, "Now" centered). _Not_ the current
+navigation model — today the app uses distinct surfaces. Retained as a possible
+future direction, not a present primitive. _Avoid_: Calendar, grid; do not treat
+as built.
 
 **Dashboard**: The logged-in athlete's home view at `/`. Currently a
 transitional surface; long-term it is a zoom level of the Tape, not a separate

--- a/docs/adr/0010-near-term-scope-form-number.md
+++ b/docs/adr/0010-near-term-scope-form-number.md
@@ -1,0 +1,20 @@
+# Near-term scope: a session tracker surfaced as one Form number
+
+The domain model and `CONTEXT.md` describe an ambitious periodized planner
+(Events with A/B/C priority, taper language, the full TSS/CTL/ATL/TSB triad, The
+Tape). For the near term we deliberately narrow scope to: simple Workout Sessions
+plus a single user-facing **Form** number (TSB) translated to plain language,
+computed from sessions and RPE. Periodization (training phases / season planning)
+and The Tape are deferred.
+
+Rationale: Excel already handles dense ledgers and periodization tables well. A
+dedicated tool's edge is heavy analysis surfaced as a few trustworthy, simple
+numbers. Form (TSB) is the highest-value daily signal and the engine already
+computes it. Cold-start is handled honestly — show "building baseline" rather
+than a misleading number, per the **Unavailable Metric** principle.
+
+## Consequences
+
+- **Training Load** stays in the model and keeps being computed; we are scoping
+  down what is *surfaced*, not removing the engine. Load remains available for
+  later forward-planning features.


### PR DESCRIPTION
Add ADR-0010 narrowing near-term scope to simple sessions surfaced as one
Form (TSB) number, deferring periodization and The Tape. Correct CONTEXT.md:
remove the false background-job claim on Load Snapshot and reframe The Tape
as a deferred idea rather than the current navigation primitive.

https://claude.ai/code/session_01SgEBzML4xRfcfefnZinkZY