### PR TITLE
feat: honest cold-start gate for the Form (TSB) metric (#57)

### DIFF
--- a/app/utils/load/snapshot.server.test.ts
+++ b/app/utils/load/snapshot.server.test.ts
@@ -2,7 +2,12 @@ import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { prisma } from '#app/utils/db.server.ts'
 import { createUser, createPassword } from '#tests/db-utils.ts'
-import { recomputeLoadFrom, getLoadSnapshots, getCurrentLoad } from './snapshot.server.ts'
+import {
+	recomputeLoadFrom,
+	getLoadSnapshots,
+	getCurrentLoad,
+	getTsbTrust,
+} from './snapshot.server.ts'
 
 async function createUserWithProfile(tz = 'UTC') {
 	const userData = createUser()
@@ -158,6 +163,54 @@ test('getCurrentLoad: returns the most recent snapshot', async () => {
 	const load = await getCurrentLoad(user.id)
 	expect(load).not.toBeNull()
 	expect(load!.date).toBe(todayStr)
+})
+
+// ── TSB trustworthiness gate ──────────────────────────────────────────────
+
+test('getTsbTrust: no snapshots → not trustworthy with zero history', async () => {
+	const user = await createUserWithProfile()
+	const trust = await getTsbTrust(user.id)
+	expect(trust.trustworthy).toBe(false)
+	expect(trust.daysOfHistory).toBe(0)
+	expect(trust.requiredDays).toBe(42)
+})
+
+test('getTsbTrust: thin history (today only) is not trustworthy', async () => {
+	const user = await createUserWithProfile()
+	const today = new Date()
+	today.setUTCHours(12, 0, 0, 0)
+	const todayStr = today.toISOString().slice(0, 10)
+
+	await createCompletedSession(user.id, today, 'run', 7, 160)
+	await recomputeLoadFrom(user.id, todayStr)
+
+	const trust = await getTsbTrust(user.id)
+	expect(trust.trustworthy).toBe(false)
+	expect(trust.daysOfHistory).toBe(1)
+})
+
+test('getTsbTrust: ≥42 days of history is trustworthy', async () => {
+	const user = await createUserWithProfile()
+
+	// Earliest snapshot 49 days before today → 50 inclusive days of history.
+	const first = new Date()
+	first.setUTCHours(12, 0, 0, 0)
+	first.setUTCDate(first.getUTCDate() - 49)
+	await prisma.loadSnapshot.create({
+		data: {
+			athleteId: user.id,
+			date: first.toISOString().slice(0, 10),
+			tssTotal: 0,
+			tssByDiscipline: '{}',
+			ctl: 0,
+			atl: 0,
+			tsb: 0,
+		},
+	})
+
+	const trust = await getTsbTrust(user.id)
+	expect(trust.daysOfHistory).toBeGreaterThanOrEqual(42)
+	expect(trust.trustworthy).toBe(true)
 })
 
 // ── timezone-correct day attribution ─────────────────────────────────────

--- a/app/utils/load/snapshot.server.ts
+++ b/app/utils/load/snapshot.server.ts
@@ -1,6 +1,11 @@
 import { prisma } from '#app/utils/db.server.ts'
 import { computeSessionTss } from './compute.ts'
 import { ewmaStep } from './ewma.ts'
+import {
+	assessTsbTrust,
+	daysOfLoadHistory,
+	type TsbTrust,
+} from './trustworthiness.ts'
 
 // NOTE: Synchronous recompute — suitable for SQLite/hobby project (ADR 0008).
 // Recomputing forwards from a changed date is O(days since change).
@@ -366,6 +371,28 @@ export async function getLoadSnapshots(
 		...r,
 		tssByDiscipline: JSON.parse(r.tssByDiscipline) as Record<string, number>,
 	}))
+}
+
+/**
+ * Determine whether the athlete's Form (TSB) is trustworthy yet, based on how
+ * many days of load history they've accumulated since their first Load
+ * Snapshot. Page-agnostic: callers render the "building baseline" progress
+ * when not trustworthy, and the real TSB number once at/above the threshold.
+ */
+export async function getTsbTrust(athleteId: string): Promise<TsbTrust> {
+	const [firstSnapshot, profile] = await Promise.all([
+		prisma.loadSnapshot.findFirst({
+			where: { athleteId },
+			orderBy: { date: 'asc' },
+			select: { date: true },
+		}),
+		prisma.athleteProfile.findUnique({
+			where: { userId: athleteId },
+			select: { timezone: true },
+		}),
+	])
+	const todayStr = toAthleteDate(new Date(), profile?.timezone ?? 'UTC')
+	return assessTsbTrust(daysOfLoadHistory(firstSnapshot?.date ?? null, todayStr))
 }
 
 /** Get the most recent snapshot (today's fitness/fatigue/form). */

--- a/app/utils/load/trustworthiness.test.ts
+++ b/app/utils/load/trustworthiness.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest'
+import {
+	TSB_TRUSTWORTHY_MIN_DAYS,
+	assessTsbTrust,
+	daysOfLoadHistory,
+} from './trustworthiness.ts'
+
+// ── threshold constant ───────────────────────────────────────────────────────
+
+test('TSB_TRUSTWORTHY_MIN_DAYS defaults to 42 (CTL time constant)', () => {
+	expect(TSB_TRUSTWORTHY_MIN_DAYS).toBe(42)
+})
+
+// ── daysOfLoadHistory ────────────────────────────────────────────────────────
+
+test('daysOfLoadHistory: no history returns 0', () => {
+	expect(daysOfLoadHistory(null, '2026-05-27')).toBe(0)
+})
+
+test('daysOfLoadHistory: first day counts as day 1', () => {
+	expect(daysOfLoadHistory('2026-05-27', '2026-05-27')).toBe(1)
+})
+
+test('daysOfLoadHistory: inclusive count across a span', () => {
+	// 2026-05-01 → 2026-05-12 is day 12 of history
+	expect(daysOfLoadHistory('2026-05-01', '2026-05-12')).toBe(12)
+})
+
+test('daysOfLoadHistory: exactly 42 days', () => {
+	// 2026-01-01 + 41 days = 2026-02-11 → day 42
+	expect(daysOfLoadHistory('2026-01-01', '2026-02-11')).toBe(42)
+})
+
+test('daysOfLoadHistory: a future first date clamps to 0', () => {
+	expect(daysOfLoadHistory('2026-06-01', '2026-05-27')).toBe(0)
+})
+
+// ── assessTsbTrust boundary ──────────────────────────────────────────────────
+
+test('assessTsbTrust: no history is not trustworthy', () => {
+	const result = assessTsbTrust(0)
+	expect(result.trustworthy).toBe(false)
+	expect(result.daysOfHistory).toBe(0)
+	expect(result.requiredDays).toBe(42)
+})
+
+test('assessTsbTrust: below threshold (41 days) is not trustworthy', () => {
+	const result = assessTsbTrust(41)
+	expect(result.trustworthy).toBe(false)
+	expect(result.daysOfHistory).toBe(41)
+})
+
+test('assessTsbTrust: exactly at threshold (42 days) is trustworthy', () => {
+	const result = assessTsbTrust(42)
+	expect(result.trustworthy).toBe(true)
+	expect(result.daysOfHistory).toBe(42)
+})
+
+test('assessTsbTrust: above threshold (100 days) is trustworthy', () => {
+	expect(assessTsbTrust(100).trustworthy).toBe(true)
+})
+
+test('assessTsbTrust: floors fractional and clamps negative input', () => {
+	expect(assessTsbTrust(41.9).daysOfHistory).toBe(41)
+	expect(assessTsbTrust(-5).daysOfHistory).toBe(0)
+	expect(assessTsbTrust(-5).trustworthy).toBe(false)
+})

--- a/app/utils/load/trustworthiness.ts
+++ b/app/utils/load/trustworthiness.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimum days of load history before the Form (TSB) number is trustworthy.
+ *
+ * Matches CTL's 42-day EWMA time constant (ADR 0008): until the athlete has
+ * roughly that much history, CTL is still climbing from zero and TSB reads
+ * artificially negative. Below this gate the Coach card shows a "building
+ * baseline" state instead of the number (Unavailable Metric principle).
+ * Tune here.
+ */
+export const TSB_TRUSTWORTHY_MIN_DAYS = 42
+
+export type TsbTrust = {
+	/** Whether the athlete has enough history for TSB to be presented as-is. */
+	trustworthy: boolean
+	/** Days of load history accumulated so far (the N in "day N/42"). */
+	daysOfHistory: number
+	/** Days of history required before TSB is trustworthy. */
+	requiredDays: number
+}
+
+/**
+ * Inclusive count of load-history days between the first recorded day and
+ * today. Both are YYYY-MM-DD in the athlete timezone. The first day counts as
+ * day 1, so a `firstDate` equal to `today` yields 1. Returns 0 when there is
+ * no history.
+ */
+export function daysOfLoadHistory(
+	firstDate: string | null,
+	today: string,
+): number {
+	if (!firstDate) return 0
+	const first = Date.parse(`${firstDate}T00:00:00.000Z`)
+	const now = Date.parse(`${today}T00:00:00.000Z`)
+	if (Number.isNaN(first) || Number.isNaN(now)) return 0
+	const diffDays = Math.round((now - first) / 86_400_000)
+	return Math.max(0, diffDays + 1)
+}
+
+/**
+ * Decide whether TSB is trustworthy given how many days of load history the
+ * athlete has accumulated. Page-agnostic: callers render the "building
+ * baseline" progress (`day {daysOfHistory}/{requiredDays}`) when not
+ * trustworthy, and the real TSB number once at/above the threshold.
+ */
+export function assessTsbTrust(daysOfHistory: number): TsbTrust {
+	const days = Math.max(0, Math.floor(daysOfHistory))
+	return {
+		trustworthy: days >= TSB_TRUSTWORTHY_MIN_DAYS,
+		daysOfHistory: days,
+		requiredDays: TSB_TRUSTWORTHY_MIN_DAYS,
+	}
+}


### PR DESCRIPTION
TSB reads artificially negative while CTL is still climbing from zero, so
present a "building baseline" state until the athlete has enough load history
to trust the number.

Add a page-agnostic trustworthiness module: TSB_TRUSTWORTHY_MIN_DAYS (default
42, matching CTL's EWMA time constant), a pure daysOfLoadHistory inclusive day
counter, and assessTsbTrust returning {trustworthy, daysOfHistory, requiredDays}
so callers can render "day N/42". getTsbTrust composes these against the
athlete's earliest Load Snapshot.

https://claude.ai/code/session_013W5aoCzjYzkTsSsR6GRf4o