### PR TITLE
feat: provide home session ledger data (past + planned) (#60)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,12 @@ structured content. _Avoid_: Session page, workout page
 grouped sessions, summary counts, discipline allocation, filters, and workout
 shape. _Avoid_: Dashboard, table page, report
 
+**Session Ledger**: The single dense, chronological list on the home surface
+spanning completed (past), missed, and planned (upcoming) workout sessions,
+ordered by date with "Now" between past and future. Each row carries date,
+discipline, title, duration, load, status, and (for completed sessions) RPE.
+_Avoid_: History, log, timeline
+
 ### Workout structure
 
 **Workout**: The structured training definition owned by a user and used as a

--- a/app/routes/_marketing/index.test.ts
+++ b/app/routes/_marketing/index.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from 'vitest'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { createSessionLog } from '#app/utils/session-log.server.ts'
+import { deriveLedgerStatus } from '#app/utils/training.ts'
 import { createUser, createPassword } from '#tests/db-utils.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
 import { loader } from './index.tsx'
@@ -198,4 +199,28 @@ test('dashboard includes recent session logs', async () => {
 	expect(data.recentLogs).toHaveLength(1)
 	expect(data.recentLogs[0]!.content).toBe('Good session')
 	expect(data.recentLogs[0]!.rpe).toBe(6)
+})
+
+test('dashboard ledger covers a mix of completed, missed, and planned sessions', async () => {
+	const session = await setupUser()
+	await createWorkoutWithSession(session.userId, inDays(-3), 'completed')
+	await createWorkoutWithSession(session.userId, inDays(-1), 'missed')
+	await createWorkoutWithSession(session.userId, inDays(2), 'scheduled')
+
+	const cookieHeader = await getSessionCookieHeader(session)
+	const request = makeRequest(cookieHeader)
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	const data = response as {
+		ledger: Array<{ scheduledAt: Date; status: string }>
+	}
+	expect(data.ledger).toHaveLength(3)
+	// ordered chronologically (past → future)
+	const times = data.ledger.map((s) => new Date(s.scheduledAt).getTime())
+	expect(times).toEqual([...times].sort((a, b) => a - b))
+	expect(data.ledger.map((s) => deriveLedgerStatus(s))).toEqual([
+		'completed',
+		'missed',
+		'planned',
+	])
 })

--- a/app/routes/_marketing/index.tsx
+++ b/app/routes/_marketing/index.tsx
@@ -24,6 +24,7 @@ import { getRecentSessionLogs } from '#app/utils/session-log.server.ts'
 import { useSessionPresenter } from '#app/utils/session-presenter.ts'
 import {
 	type UpcomingSession,
+	getSessionLedger,
 	getUpcomingSessions,
 } from '#app/utils/training.server.ts'
 import {
@@ -44,9 +45,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 	if (!userId) {
 		return { isAuthenticated: false as const }
 	}
-	const [sessions, recentLogs] = await Promise.all([
+	const [sessions, recentLogs, ledger] = await Promise.all([
 		getUpcomingSessions(userId),
 		getRecentSessionLogs(userId),
+		getSessionLedger(userId),
 	])
 	const nextSession = sessions[0] ?? null
 	const upcomingSessions = sessions.slice(1)
@@ -55,6 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		nextSession,
 		upcomingSessions,
 		recentLogs,
+		ledger,
 	}
 }
 

--- a/app/utils/training.server.test.ts
+++ b/app/utils/training.server.test.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { prisma } from '#app/utils/db.server.ts'
 import { createUser, createPassword } from '#tests/db-utils.ts'
-import { getUpcomingSessions } from './training.server.ts'
+import { getSessionLedger, getUpcomingSessions } from './training.server.ts'
 
 async function createUserWithPassword() {
 	const userData = createUser()
@@ -189,4 +189,110 @@ test('includes sessions of all statuses in the upcoming window', async () => {
 		'skipped',
 		'missed',
 	])
+})
+
+test('getSessionLedger returns past and future sessions ordered by date', async () => {
+	const user = await createUserWithPassword()
+	const workout = await createWorkoutForUser(user.id)
+	await prisma.workoutSession.createMany({
+		data: [
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: inDays(2),
+				status: 'scheduled',
+			},
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: daysAgo(3),
+				status: 'completed',
+			},
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: daysAgo(1),
+				status: 'missed',
+			},
+		],
+	})
+	const ledger = await getSessionLedger(user.id)
+	expect(ledger.map((s) => s.status)).toEqual([
+		'completed',
+		'missed',
+		'scheduled',
+	])
+})
+
+test('getSessionLedger is bounded by the trailing window and planned horizon', async () => {
+	const user = await createUserWithPassword()
+	const workout = await createWorkoutForUser(user.id)
+	await prisma.workoutSession.createMany({
+		data: [
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: daysAgo(60),
+				status: 'completed',
+			},
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: daysAgo(10),
+				status: 'completed',
+			},
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: inDays(5),
+				status: 'scheduled',
+			},
+			{
+				userId: user.id,
+				workoutId: workout.id,
+				scheduledAt: inDays(20),
+				status: 'scheduled',
+			},
+		],
+	})
+	const ledger = await getSessionLedger(user.id)
+	expect(ledger).toHaveLength(2)
+})
+
+test('getSessionLedger excludes sessions belonging to another user', async () => {
+	const userA = await createUserWithPassword()
+	const userB = await createUserWithPassword()
+	const workout = await createWorkoutForUser(userA.id)
+	await prisma.workoutSession.create({
+		data: {
+			userId: userA.id,
+			workoutId: workout.id,
+			scheduledAt: daysAgo(2),
+			status: 'completed',
+		},
+	})
+	const ledger = await getSessionLedger(userB.id)
+	expect(ledger).toHaveLength(0)
+})
+
+test('getSessionLedger carries load and RPE for completed sessions', async () => {
+	const user = await createUserWithPassword()
+	const workout = await createWorkoutForUser(user.id)
+	const completed = await prisma.workoutSession.create({
+		data: {
+			userId: user.id,
+			workoutId: workout.id,
+			scheduledAt: daysAgo(1),
+			status: 'completed',
+			tssValue: 72,
+		},
+		select: { id: true },
+	})
+	await prisma.sessionLog.create({
+		data: { sessionId: completed.id, content: 'solid', rpe: 8 },
+	})
+	const ledger = await getSessionLedger(user.id)
+	expect(ledger).toHaveLength(1)
+	expect(ledger[0]?.tssValue).toBe(72)
+	expect(ledger[0]?.sessionLog?.rpe).toBe(8)
 })

--- a/app/utils/training.server.ts
+++ b/app/utils/training.server.ts
@@ -133,6 +133,48 @@ export async function getUpcomingSessions(
 	})
 }
 
+const ledgerSessionSelect = {
+	...upcomingSessionSelect,
+	tssValue: true,
+	sessionLog: {
+		select: {
+			id: true,
+			rpe: true,
+		},
+	},
+} satisfies Prisma.WorkoutSessionSelect
+
+export type LedgerSession = Prisma.WorkoutSessionGetPayload<{
+	select: typeof ledgerSessionSelect
+}>
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Chronological session ledger spanning completed (past) and planned (upcoming)
+ * sessions, ordered by date. Bounded by a trailing history window plus the
+ * planned horizon so the query stays sensible for athletes with long histories.
+ */
+export async function getSessionLedger(
+	userId: string,
+	{
+		trailingDays = 42,
+		horizonDays = 14,
+		now = new Date(),
+	}: { trailingDays?: number; horizonDays?: number; now?: Date } = {},
+): Promise<LedgerSession[]> {
+	const from = new Date(now.getTime() - trailingDays * DAY_MS)
+	const to = new Date(now.getTime() + horizonDays * DAY_MS)
+	return prisma.workoutSession.findMany({
+		where: {
+			userId,
+			scheduledAt: { gte: from, lte: to },
+		},
+		orderBy: { scheduledAt: 'asc' },
+		select: ledgerSessionSelect,
+	})
+}
+
 const sessionDetailSelect = {
 	...upcomingSessionSelect,
 	sessionLog: {

--- a/app/utils/training.test.ts
+++ b/app/utils/training.test.ts
@@ -1,9 +1,14 @@
 import { expect, test } from 'vitest'
 import {
+	deriveLedgerStatus,
 	getDisciplineLabel,
+	getSessionDurationMin,
 	getStatusLabel,
 	getStatusVariant,
+	toSessionLedgerEntry,
 } from './training.ts'
+
+const inDays = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000)
 
 test('getStatusVariant maps known statuses to badge variants', () => {
 	expect(getStatusVariant('scheduled')).toBe('secondary')
@@ -33,4 +38,104 @@ test('getDisciplineLabel capitalizes disciplines', () => {
 
 test('getDisciplineLabel maps bike to Ride', () => {
 	expect(getDisciplineLabel('bike')).toBe('Ride')
+})
+
+test('deriveLedgerStatus maps completed sessions to completed', () => {
+	expect(
+		deriveLedgerStatus({ status: 'completed', scheduledAt: inDays(-1) }),
+	).toBe('completed')
+})
+
+test('deriveLedgerStatus maps missed and skipped to missed', () => {
+	expect(
+		deriveLedgerStatus({ status: 'missed', scheduledAt: inDays(-1) }),
+	).toBe('missed')
+	expect(
+		deriveLedgerStatus({ status: 'skipped', scheduledAt: inDays(-1) }),
+	).toBe('missed')
+})
+
+test('deriveLedgerStatus treats future scheduled sessions as planned', () => {
+	expect(
+		deriveLedgerStatus({ status: 'scheduled', scheduledAt: inDays(2) }),
+	).toBe('planned')
+})
+
+test('deriveLedgerStatus treats past scheduled sessions as missed', () => {
+	expect(
+		deriveLedgerStatus({ status: 'scheduled', scheduledAt: inDays(-2) }),
+	).toBe('missed')
+})
+
+test('getSessionDurationMin prefers the recording actual duration', () => {
+	const min = getSessionDurationMin({
+		recording: { durationSec: 1800 },
+		workout: {
+			blocks: [{ repeatCount: 1, steps: [{ durationSec: 600 }] }],
+		},
+	})
+	expect(min).toBe(30)
+})
+
+test('getSessionDurationMin falls back to planned step duration', () => {
+	const min = getSessionDurationMin({
+		recording: null,
+		workout: {
+			blocks: [{ repeatCount: 2, steps: [{ durationSec: 600 }] }],
+		},
+	})
+	expect(min).toBe(20)
+})
+
+test('getSessionDurationMin returns null with no recording or workout', () => {
+	expect(getSessionDurationMin({ recording: null, workout: null })).toBeNull()
+})
+
+test('toSessionLedgerEntry projects the normalized ledger fields', () => {
+	const entry = toSessionLedgerEntry({
+		id: 'session-1',
+		scheduledAt: inDays(-1),
+		status: 'completed',
+		tssValue: 55,
+		workout: {
+			title: 'Tempo Run',
+			discipline: 'run',
+			blocks: [{ repeatCount: 1, steps: [{ durationSec: 2400 }] }],
+		},
+		recording: { discipline: 'run', durationSec: 2700 },
+		sessionLog: { rpe: 7 },
+	})
+	expect(entry).toMatchObject({
+		id: 'session-1',
+		discipline: 'run',
+		title: 'Tempo Run',
+		status: 'completed',
+		durationMin: 45,
+		load: 55,
+		rpe: 7,
+	})
+})
+
+test('toSessionLedgerEntry handles a planned session with no log or recording', () => {
+	const entry = toSessionLedgerEntry({
+		id: 'session-2',
+		scheduledAt: inDays(3),
+		status: 'scheduled',
+		tssValue: null,
+		workout: {
+			title: 'Easy Spin',
+			discipline: 'bike',
+			blocks: [{ repeatCount: 1, steps: [{ durationSec: 3600 }] }],
+		},
+		recording: null,
+		sessionLog: null,
+	})
+	expect(entry).toMatchObject({
+		discipline: 'bike',
+		title: 'Easy Spin',
+		status: 'planned',
+		durationMin: 60,
+		load: null,
+		rpe: null,
+	})
 })

--- a/app/utils/training.ts
+++ b/app/utils/training.ts
@@ -1,3 +1,5 @@
+import { sumBlockDurationMin } from './dashboard.ts'
+
 export type StatusBadgeVariant =
 	| 'default'
 	| 'secondary'
@@ -40,4 +42,86 @@ export function getSessionDiscipline(session: {
 /** True when the session has no linked workout (was created from a recording only). */
 export function isRecordingOnly(session: { workout: unknown | null }): boolean {
 	return session.workout === null
+}
+
+/**
+ * The three states the session ledger distinguishes so it can split past from
+ * future and render the right status. The stored `skipped` status and any
+ * past-but-still-scheduled session both read as `missed` (it wasn't done).
+ */
+export type LedgerStatus = 'completed' | 'planned' | 'missed'
+
+export function deriveLedgerStatus(
+	session: { status: string; scheduledAt: Date },
+	now: Date = new Date(),
+): LedgerStatus {
+	if (session.status === 'completed') return 'completed'
+	if (session.status === 'missed' || session.status === 'skipped') {
+		return 'missed'
+	}
+	return session.scheduledAt.getTime() >= now.getTime() ? 'planned' : 'missed'
+}
+
+/** Actual duration (from the recording) when present, else the planned duration derived from the workout steps. */
+export function getSessionDurationMin(session: {
+	recording: { durationSec: number | null } | null
+	workout: {
+		blocks: Array<{
+			repeatCount: number
+			steps: Array<{ durationSec: number | null }>
+		}>
+	} | null
+}): number | null {
+	if (session.recording?.durationSec != null) {
+		return Math.round(session.recording.durationSec / 60)
+	}
+	if (session.workout) {
+		return sumBlockDurationMin(session.workout.blocks)
+	}
+	return null
+}
+
+/** The normalized shape each ledger row carries: date, discipline, title, duration, load, status, and RPE. */
+export type SessionLedgerEntry = {
+	id: string
+	scheduledAt: Date
+	discipline: string
+	title: string | null
+	status: LedgerStatus
+	durationMin: number | null
+	load: number | null
+	rpe: number | null
+}
+
+export function toSessionLedgerEntry(
+	session: {
+		id: string
+		scheduledAt: Date
+		status: string
+		tssValue: number | null
+		workout:
+			| {
+					title: string
+					discipline: string
+					blocks: Array<{
+						repeatCount: number
+						steps: Array<{ durationSec: number | null }>
+					}>
+			  }
+			| null
+		recording: { discipline: string; durationSec: number | null } | null
+		sessionLog: { rpe: number | null } | null
+	},
+	now: Date = new Date(),
+): SessionLedgerEntry {
+	return {
+		id: session.id,
+		scheduledAt: session.scheduledAt,
+		discipline: getSessionDiscipline(session),
+		title: session.workout?.title ?? null,
+		status: deriveLedgerStatus(session, now),
+		durationMin: getSessionDurationMin(session),
+		load: session.tssValue ?? null,
+		rpe: session.sessionLog?.rpe ?? null,
+	}
 }


### PR DESCRIPTION
Broaden the home loader to return a single chronological session ledger
spanning completed, missed, and planned workout sessions, bounded by a
trailing history window plus the 14-day planned horizon and ordered by
date. Add pure helpers to derive each row's ledger status (completed /
planned / missed), actual-vs-planned duration, load, and RPE.

https://claude.ai/code/session_01JQ3Wpkp6kBb7A599XLxKV8