### PR TITLE
feat: surface Form (TSB) as the home page Coach card (#59)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,9 +165,17 @@ navigation model — today the app uses distinct surfaces. Retained as a possibl
 future direction, not a present primitive. _Avoid_: Calendar, grid; do not treat
 as built.
 
-**Dashboard**: The logged-in athlete's home view at `/`. Currently a
-transitional surface; long-term it is a zoom level of the Tape, not a separate
-concept. _Avoid_: Home page, landing page, feed
+**Dashboard**: The logged-in athlete's home view at `/`, and the default
+destination after login. Its primary, top signal is the **Coach card**, with the
+**Session Ledger** below it (ADR 0010). Long-term it is a zoom level of the
+Tape, not a separate concept. _Avoid_: Home page, landing page, feed
+
+**Coach card**: The headline Form (TSB) signal at the top of the home view — the
+single daily "go hard or recover?" answer. While Form (TSB) is untrustworthy
+(thin load history) it shows a "building baseline — day N/42" state; once
+trustworthy it shows the plain-language readiness label plus a short
+recommendation. It lives on the home surface, not on a separate Training Load
+page. _Avoid_: TSB widget, form box, readiness card
 
 ### Recording and import
 

--- a/app/routes/_marketing/index.dashboard.test.tsx
+++ b/app/routes/_marketing/index.dashboard.test.tsx
@@ -35,16 +35,28 @@ type RecentLog = {
 	session: { id: string; workout: { title: string } | null }
 }
 
+type TsbTrust = {
+	trustworthy: boolean
+	daysOfHistory: number
+	requiredDays: number
+}
+
 function dashboardLoader(
 	nextSession: UpcomingSession | null,
 	upcomingSessions: UpcomingSession[] = [],
 	recentLogs: RecentLog[] = [],
+	coach: { tsb: number | null; tsbTrust: TsbTrust } = {
+		tsb: null,
+		tsbTrust: { trustworthy: false, daysOfHistory: 0, requiredDays: 42 },
+	},
 ) {
 	return async (_args: LoaderFunctionArgs) => ({
 		isAuthenticated: true as const,
 		nextSession,
 		upcomingSessions,
 		recentLogs,
+		tsb: coach.tsb,
+		tsbTrust: coach.tsbTrust,
 	})
 }
 
@@ -179,6 +191,31 @@ test('dashboard hides recent reflections when no logs', async () => {
 	expect(
 		screen.queryByRole('heading', { name: /recent reflections/i }),
 	).not.toBeInTheDocument()
+})
+
+test('coach card shows building-baseline cold-start when TSB is untrustworthy', async () => {
+	renderRoute(
+		dashboardLoader(null, [], [], {
+			tsb: null,
+			tsbTrust: { trustworthy: false, daysOfHistory: 12, requiredDays: 42 },
+		}),
+	)
+
+	await screen.findByText(/building baseline/i)
+	expect(screen.getByText(/day 12\/42/i)).toBeInTheDocument()
+})
+
+test('coach card shows readiness label and signed TSB when trustworthy', async () => {
+	renderRoute(
+		dashboardLoader(null, [], [], {
+			tsb: 7,
+			tsbTrust: { trustworthy: true, daysOfHistory: 60, requiredDays: 42 },
+		}),
+	)
+
+	await screen.findByText('+7')
+	expect(screen.getByText(/fresh/i)).toBeInTheDocument()
+	expect(screen.queryByText(/building baseline/i)).not.toBeInTheDocument()
 })
 
 test('dashboard shows upcoming this week for sessions not on focused day', async () => {

--- a/app/routes/_marketing/index.test.ts
+++ b/app/routes/_marketing/index.test.ts
@@ -201,6 +201,61 @@ test('dashboard includes recent session logs', async () => {
 	expect(data.recentLogs[0]!.rpe).toBe(6)
 })
 
+const utcDayKey = (n: number) =>
+	new Date(Date.now() + n * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+
+async function createLoadSnapshot(
+	athleteId: string,
+	date: string,
+	tsb: number,
+) {
+	return prisma.loadSnapshot.create({
+		data: {
+			athleteId,
+			date,
+			tssTotal: 0,
+			tssByDiscipline: '{}',
+			ctl: 0,
+			atl: 0,
+			tsb,
+			computedAt: new Date(),
+		},
+	})
+}
+
+test('coach card data: no load history is an untrustworthy cold-start', async () => {
+	const session = await setupUser()
+	const cookieHeader = await getSessionCookieHeader(session)
+	const request = makeRequest(cookieHeader)
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	const data = response as {
+		tsb: number | null
+		tsbTrust: { trustworthy: boolean; daysOfHistory: number; requiredDays: number }
+	}
+	expect(data.tsb).toBeNull()
+	expect(data.tsbTrust.trustworthy).toBe(false)
+	expect(data.tsbTrust.daysOfHistory).toBe(0)
+})
+
+test('coach card data: 42+ days of history surfaces a trustworthy TSB', async () => {
+	const session = await setupUser()
+	await createLoadSnapshot(session.userId, utcDayKey(-50), -3)
+	await createLoadSnapshot(session.userId, utcDayKey(0), 7)
+
+	const cookieHeader = await getSessionCookieHeader(session)
+	const request = makeRequest(cookieHeader)
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	const data = response as {
+		tsb: number | null
+		tsbTrust: { trustworthy: boolean; daysOfHistory: number }
+	}
+	expect(data.tsbTrust.trustworthy).toBe(true)
+	expect(data.tsbTrust.daysOfHistory).toBe(51)
+	expect(data.tsb).toBe(7)
+})
+
 test('dashboard ledger covers a mix of completed, missed, and planned sessions', async () => {
 	const session = await setupUser()
 	await createWorkoutWithSession(session.userId, inDays(-3), 'completed')

--- a/app/routes/_marketing/index.tsx
+++ b/app/routes/_marketing/index.tsx
@@ -18,6 +18,12 @@ import {
 	paletteFor,
 	sumBlockDurationMin,
 } from '#app/utils/dashboard.ts'
+import { readinessFromTsb } from '#app/utils/load/readiness.ts'
+import {
+	getCurrentLoad,
+	getTsbTrust,
+} from '#app/utils/load/snapshot.server.ts'
+import { type TsbTrust } from '#app/utils/load/trustworthiness.ts'
 import { cn } from '#app/utils/misc.tsx'
 import { useOptionalRequestInfo } from '#app/utils/request-info.ts'
 import { getRecentSessionLogs } from '#app/utils/session-log.server.ts'
@@ -34,9 +40,9 @@ import {
 	getStatusVariant,
 } from '#app/utils/training.ts'
 import { useOptionalUser } from '#app/utils/user.ts'
-import { DashboardWithNav, isNavKey } from './__dashboard-prototype.tsx'
 import { logos } from './+logos/logos.ts'
 import { type Route } from './+types/index.ts'
+import { DashboardWithNav, isNavKey } from './__dashboard-prototype.tsx'
 
 export const meta: Route.MetaFunction = () => [{ title: 'Trainm8' }]
 
@@ -45,11 +51,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 	if (!userId) {
 		return { isAuthenticated: false as const }
 	}
-	const [sessions, recentLogs, ledger] = await Promise.all([
-		getUpcomingSessions(userId),
-		getRecentSessionLogs(userId),
-		getSessionLedger(userId),
-	])
+	const [sessions, recentLogs, ledger, currentLoad, tsbTrust] =
+		await Promise.all([
+			getUpcomingSessions(userId),
+			getRecentSessionLogs(userId),
+			getSessionLedger(userId),
+			getCurrentLoad(userId),
+			getTsbTrust(userId),
+		])
 	const nextSession = sessions[0] ?? null
 	const upcomingSessions = sessions.slice(1)
 	return {
@@ -58,6 +67,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 		upcomingSessions,
 		recentLogs,
 		ledger,
+		tsb: currentLoad?.tsb ?? null,
+		tsbTrust,
 	}
 }
 
@@ -117,9 +128,11 @@ function Dashboard({
 		nextSession: UpcomingSession | null
 		upcomingSessions: UpcomingSession[]
 		recentLogs: RecentLog[]
+		tsb: number | null
+		tsbTrust: TsbTrust
 	}
 }) {
-	const { nextSession, upcomingSessions, recentLogs } = data
+	const { nextSession, upcomingSessions, recentLogs, tsb, tsbTrust } = data
 	const [searchParams] = useSearchParams()
 	const presenter = useSessionPresenter()
 	const user = useOptionalUser()
@@ -230,6 +243,8 @@ function Dashboard({
 						New session
 					</Button>
 				</header>
+
+				<CoachCard tsb={tsb} trust={tsbTrust} />
 
 				<section aria-labelledby="today-heading">
 					<div className="mb-4 flex items-baseline justify-between">
@@ -526,6 +541,115 @@ function InlineStat({
 				<span className="text-muted-foreground text-xs">{unit}</span>
 			) : null}
 		</div>
+	)
+}
+
+const READINESS_TONE: Record<
+	ReturnType<typeof readinessFromTsb>['tone'],
+	{ chip: string; accent: string }
+> = {
+	fresh: {
+		chip: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+		accent: 'text-emerald-600 dark:text-emerald-400',
+	},
+	neutral: {
+		chip: 'bg-muted text-muted-foreground',
+		accent: 'text-foreground',
+	},
+	fatigued: {
+		chip: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+		accent: 'text-amber-600 dark:text-amber-400',
+	},
+}
+
+function CoachCard({ tsb, trust }: { tsb: number | null; trust: TsbTrust }) {
+	// Cold-start (#57): below the trustworthiness threshold — or with no TSB
+	// computed yet — show the honest "building baseline" state, never a number.
+	if (!trust.trustworthy || tsb == null) {
+		const pct = Math.min(
+			100,
+			Math.round((trust.daysOfHistory / trust.requiredDays) * 100),
+		)
+		return (
+			<section
+				aria-labelledby="coach-heading"
+				className="bg-card border-border/60 rounded-xl border p-6"
+			>
+				<p
+					id="coach-heading"
+					className="text-muted-foreground text-xs font-medium tracking-wide uppercase"
+				>
+					Form
+				</p>
+				<p className="text-foreground mt-2 text-2xl font-semibold tracking-tight">
+					Building baseline
+				</p>
+				<p className="text-muted-foreground mt-1 text-sm">
+					Keep logging sessions — your Form reading is reliable after{' '}
+					{trust.requiredDays} days of training history.
+				</p>
+				<div className="mt-4 flex items-center gap-3">
+					<div
+						className="bg-muted h-2 flex-1 overflow-hidden rounded-full"
+						role="progressbar"
+						aria-valuemin={0}
+						aria-valuemax={trust.requiredDays}
+						aria-valuenow={trust.daysOfHistory}
+						aria-label="Days of training history toward a reliable Form reading"
+					>
+						<div
+							className="bg-primary h-full rounded-full"
+							style={{ width: `${pct}%` }}
+						/>
+					</div>
+					<span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+						day {trust.daysOfHistory}/{trust.requiredDays}
+					</span>
+				</div>
+			</section>
+		)
+	}
+
+	// Trustworthy (#58): translate the number into a plain-language readiness
+	// label + recommendation.
+	const readiness = readinessFromTsb(tsb)
+	const rounded = Math.round(tsb)
+	const signed = rounded > 0 ? `+${rounded}` : String(rounded)
+	const tone = READINESS_TONE[readiness.tone]
+
+	return (
+		<section
+			aria-labelledby="coach-heading"
+			className="bg-card border-border/60 rounded-xl border p-6"
+		>
+			<p
+				id="coach-heading"
+				className="text-muted-foreground text-xs font-medium tracking-wide uppercase"
+			>
+				Form
+			</p>
+			<div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+				<span
+					className={cn(
+						'text-4xl font-semibold tracking-tight tabular-nums',
+						tone.accent,
+					)}
+				>
+					{signed}
+				</span>
+				<span
+					className={cn(
+						'rounded-full px-2.5 py-0.5 text-sm font-medium',
+						tone.chip,
+					)}
+				>
+					{readiness.label}
+				</span>
+			</div>
+			<p className="text-muted-foreground mt-2 text-sm">
+				{readiness.recommendation}
+			</p>
+		</section>
 	)
 }
 

--- a/docs/adr/0010-near-term-scope-form-number.md
+++ b/docs/adr/0010-near-term-scope-form-number.md
@@ -2,10 +2,10 @@
 
 The domain model and `CONTEXT.md` describe an ambitious periodized planner
 (Events with A/B/C priority, taper language, the full TSS/CTL/ATL/TSB triad, The
-Tape). For the near term we deliberately narrow scope to: simple Workout Sessions
-plus a single user-facing **Form** number (TSB) translated to plain language,
-computed from sessions and RPE. Periodization (training phases / season planning)
-and The Tape are deferred.
+Tape). For the near term we deliberately narrow scope to: simple Workout
+Sessions plus a single user-facing **Form** number (TSB) translated to plain
+language, computed from sessions and RPE. Periodization (training phases /
+season planning) and The Tape are deferred.
 
 Rationale: Excel already handles dense ledgers and periodization tables well. A
 dedicated tool's edge is heavy analysis surfaced as a few trustworthy, simple
@@ -16,5 +16,19 @@ than a misleading number, per the **Unavailable Metric** principle.
 ## Consequences
 
 - **Training Load** stays in the model and keeps being computed; we are scoping
-  down what is *surfaced*, not removing the engine. Load remains available for
+  down what is _surfaced_, not removing the engine. Load remains available for
   later forward-planning features.
+
+## Placement (resolved)
+
+The "which surface" question — previously deferred — is resolved via prototype:
+the Form (TSB) number lives as the **Coach card at the top of the home page**
+(`/`), with the dense session ledger directly below it. We are **not** building
+a separate `/training/load` destination as the primary daily surface; the
+existing `/training/load` page remains only as a secondary detail view.
+
+- Below the trustworthiness threshold (see ADR 0008 and the cold-start gate) the
+  Coach card shows a "building baseline — day N/42" state instead of a number.
+- At/above the threshold it shows the plain-language readiness label plus a
+  short recommendation, derived from the TSB value.
+- The home surface (`/`) is the athlete's default destination after login.


### PR DESCRIPTION
Render the Form (TSB) signal as the primary, top "Coach card" on the home
surface. The home loader now provides current TSB and days of load history,
and the card composes the #57 cold-start gate with the #58 plain-language
readiness label: below the trustworthiness threshold it shows a
"building baseline — day N/42" state, and at/above it the signed TSB plus a
readiness label and recommendation.

Record the resolved placement (home, not a separate /training/load page) in
ADR 0010 and CONTEXT.md.

https://claude.ai/code/session_01NQkhneQe5QDV2kKf5MMq7u