### PR TITLE
feat: virtualized session ledger on the home page (#61)

### DIFF
--- a/app/components/ui/table.tsx
+++ b/app/components/ui/table.tsx
@@ -1,0 +1,70 @@
+import { type ComponentProps } from 'react'
+import { cn } from '#app/utils/misc.tsx'
+
+function Table({ className, ...props }: ComponentProps<'table'>) {
+	return (
+		<table
+			data-slot="table"
+			className={cn('w-full caption-bottom text-sm', className)}
+			{...props}
+		/>
+	)
+}
+
+function TableHeader({ className, ...props }: ComponentProps<'thead'>) {
+	return (
+		<thead
+			data-slot="table-header"
+			className={cn('[&_tr]:border-b', className)}
+			{...props}
+		/>
+	)
+}
+
+function TableBody({ className, ...props }: ComponentProps<'tbody'>) {
+	return (
+		<tbody
+			data-slot="table-body"
+			className={cn('[&_tr:last-child]:border-0', className)}
+			{...props}
+		/>
+	)
+}
+
+function TableRow({ className, ...props }: ComponentProps<'tr'>) {
+	return (
+		<tr
+			data-slot="table-row"
+			className={cn(
+				'border-border/60 hover:bg-muted/40 data-[state=selected]:bg-muted border-b transition-colors',
+				className,
+			)}
+			{...props}
+		/>
+	)
+}
+
+function TableHead({ className, ...props }: ComponentProps<'th'>) {
+	return (
+		<th
+			data-slot="table-head"
+			className={cn(
+				'text-muted-foreground h-9 px-3 text-left align-middle text-xs font-medium tracking-wide whitespace-nowrap',
+				className,
+			)}
+			{...props}
+		/>
+	)
+}
+
+function TableCell({ className, ...props }: ComponentProps<'td'>) {
+	return (
+		<td
+			data-slot="table-cell"
+			className={cn('px-3 align-middle whitespace-nowrap', className)}
+			{...props}
+		/>
+	)
+}
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }

--- a/app/routes/_marketing/index.dashboard.test.tsx
+++ b/app/routes/_marketing/index.dashboard.test.tsx
@@ -3,8 +3,11 @@
  */
 import { render, screen } from '@testing-library/react'
 import { createRoutesStub, type LoaderFunctionArgs } from 'react-router'
-import { expect, test } from 'vitest'
-import { type UpcomingSession } from '#app/utils/training.server.ts'
+import { afterAll, beforeAll, expect, test, vi } from 'vitest'
+import {
+	type LedgerSession,
+	type UpcomingSession,
+} from '#app/utils/training.server.ts'
 import IndexRoute from './index.tsx'
 
 function makeSession(
@@ -23,6 +26,28 @@ function makeSession(
 			blocks: [],
 		},
 		recording: null,
+		...overrides,
+	}
+}
+
+function makeLedgerSession(
+	overrides: Partial<LedgerSession> = {},
+): LedgerSession {
+	return {
+		id: 'ledger-1',
+		scheduledAt: new Date('2030-01-02T08:00:00.000Z'),
+		status: 'scheduled',
+		tssValue: null,
+		workout: {
+			id: 'workout-1',
+			title: 'Morning Run',
+			description: null,
+			discipline: 'run',
+			intent: 'endurance',
+			blocks: [],
+		},
+		recording: null,
+		sessionLog: null,
 		...overrides,
 	}
 }
@@ -49,12 +74,14 @@ function dashboardLoader(
 		tsb: null,
 		tsbTrust: { trustworthy: false, daysOfHistory: 0, requiredDays: 42 },
 	},
+	ledger: LedgerSession[] = [],
 ) {
 	return async (_args: LoaderFunctionArgs) => ({
 		isAuthenticated: true as const,
 		nextSession,
 		upcomingSessions,
 		recentLogs,
+		ledger,
 		tsb: coach.tsb,
 		tsbTrust: coach.tsbTrust,
 	})
@@ -84,6 +111,53 @@ function renderRoute(
 	render(<App initialEntries={[initialPath]} />)
 }
 
+// TanStack Virtual measures its scroll element (via offsetWidth/offsetHeight)
+// to decide which rows to mount; jsdom reports zero-size layout, so give the
+// virtualizer a real viewport.
+const originalOffsets = {
+	width: Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth'),
+	height: Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		'offsetHeight',
+	),
+}
+
+beforeAll(() => {
+	if (!('ResizeObserver' in globalThis)) {
+		globalThis.ResizeObserver = class {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as unknown as typeof ResizeObserver
+	}
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+		configurable: true,
+		get: () => 1024,
+	})
+	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+		configurable: true,
+		get: () => 640,
+	})
+})
+
+afterAll(() => {
+	vi.restoreAllMocks()
+	if (originalOffsets.width) {
+		Object.defineProperty(
+			HTMLElement.prototype,
+			'offsetWidth',
+			originalOffsets.width,
+		)
+	}
+	if (originalOffsets.height) {
+		Object.defineProperty(
+			HTMLElement.prototype,
+			'offsetHeight',
+			originalOffsets.height,
+		)
+	}
+})
+
 test('unauthenticated user sees marketing landing page', async () => {
 	renderRoute(marketingLoader())
 	await screen.findByText(/the epic stack/i)
@@ -95,13 +169,49 @@ test('authenticated user sees week strip dashboard with greeting', async () => {
 	await screen.findByRole('heading', { name: /here's your week/i })
 })
 
-test('dashboard shows 7-day week navigation', async () => {
+test('dashboard renders the session ledger heading', async () => {
 	renderRoute(dashboardLoader(null))
 
-	const nav = await screen.findByRole('navigation', {
-		name: /week navigation/i,
-	})
-	expect(nav).toBeInTheDocument()
+	await screen.findByRole('heading', { name: /session ledger/i })
+})
+
+test('session ledger lists completed past and planned future sessions', async () => {
+	const ledger = [
+		makeLedgerSession({
+			id: 'past-1',
+			scheduledAt: new Date('2030-01-01T08:00:00.000Z'),
+			status: 'completed',
+			tssValue: 65,
+			workout: {
+				id: 'w-past',
+				title: 'Recovery Spin',
+				description: null,
+				discipline: 'bike',
+				intent: 'recovery',
+				blocks: [],
+			},
+			sessionLog: { id: 'log-1', rpe: 4 },
+		}),
+		makeLedgerSession({
+			id: 'future-1',
+			scheduledAt: new Date('2030-01-09T08:00:00.000Z'),
+			status: 'scheduled',
+			workout: {
+				id: 'w-future',
+				title: 'Threshold Intervals',
+				description: null,
+				discipline: 'run',
+				intent: 'threshold',
+				blocks: [],
+			},
+		}),
+	]
+	renderRoute(dashboardLoader(null, [], [], undefined, ledger))
+
+	expect(await screen.findByText('Recovery Spin')).toBeInTheDocument()
+	expect(screen.getByText('Threshold Intervals')).toBeInTheDocument()
+	// The "Now" divider separates past from planned.
+	expect(screen.getByText(/^now$/i)).toBeInTheDocument()
 })
 
 test('dashboard shows rest day when focused day has no sessions', async () => {
@@ -218,27 +328,8 @@ test('coach card shows readiness label and signed TSB when trustworthy', async (
 	expect(screen.queryByText(/building baseline/i)).not.toBeInTheDocument()
 })
 
-test('dashboard shows upcoming this week for sessions not on focused day', async () => {
-	// Focus on 2030-01-02 (next session's day); Z2 Ride on 2030-01-09 is a different day
-	const next = makeSession({
-		id: 'next-1',
-		scheduledAt: new Date('2030-01-02T08:00:00.000Z'),
-	})
-	const upcoming = [
-		makeSession({
-			id: 's-2',
-			scheduledAt: new Date('2030-01-09T08:00:00.000Z'),
-			workout: {
-				id: 'w-2',
-				title: 'Z2 Ride',
-				description: null,
-				discipline: 'bike',
-				intent: 'endurance',
-				blocks: [],
-			},
-		}),
-	]
-	renderRoute(dashboardLoader(next, upcoming), '/?day=2030-01-02')
+test('session ledger shows an empty state when there are no sessions', async () => {
+	renderRoute(dashboardLoader(null, [], [], undefined, []))
 
-	await screen.findByRole('heading', { name: /this week/i })
+	await screen.findByText(/no sessions yet/i)
 })

--- a/app/routes/_marketing/index.tsx
+++ b/app/routes/_marketing/index.tsx
@@ -19,16 +19,14 @@ import {
 	sumBlockDurationMin,
 } from '#app/utils/dashboard.ts'
 import { readinessFromTsb } from '#app/utils/load/readiness.ts'
-import {
-	getCurrentLoad,
-	getTsbTrust,
-} from '#app/utils/load/snapshot.server.ts'
+import { getCurrentLoad, getTsbTrust } from '#app/utils/load/snapshot.server.ts'
 import { type TsbTrust } from '#app/utils/load/trustworthiness.ts'
 import { cn } from '#app/utils/misc.tsx'
 import { useOptionalRequestInfo } from '#app/utils/request-info.ts'
 import { getRecentSessionLogs } from '#app/utils/session-log.server.ts'
 import { useSessionPresenter } from '#app/utils/session-presenter.ts'
 import {
+	type LedgerSession,
 	type UpcomingSession,
 	getSessionLedger,
 	getUpcomingSessions,
@@ -43,6 +41,7 @@ import { useOptionalUser } from '#app/utils/user.ts'
 import { logos } from './+logos/logos.ts'
 import { type Route } from './+types/index.ts'
 import { DashboardWithNav, isNavKey } from './__dashboard-prototype.tsx'
+import { SessionLedger } from './session-ledger.tsx'
 
 export const meta: Route.MetaFunction = () => [{ title: 'Trainm8' }]
 
@@ -128,11 +127,13 @@ function Dashboard({
 		nextSession: UpcomingSession | null
 		upcomingSessions: UpcomingSession[]
 		recentLogs: RecentLog[]
+		ledger: LedgerSession[]
 		tsb: number | null
 		tsbTrust: TsbTrust
 	}
 }) {
-	const { nextSession, upcomingSessions, recentLogs, tsb, tsbTrust } = data
+	const { nextSession, upcomingSessions, recentLogs, ledger, tsb, tsbTrust } =
+		data
 	const [searchParams] = useSearchParams()
 	const presenter = useSessionPresenter()
 	const user = useOptionalUser()
@@ -203,10 +204,6 @@ function Dashboard({
 	const nextCountdown = nextSession
 		? countdownLabel(new Date(nextSession.scheduledAt))
 		: null
-
-	const upcomingThisWeek = allSessions
-		.filter((s) => isoDayKey(new Date(s.scheduledAt)) !== focusedKey)
-		.slice(0, 4)
 
 	const focusedDayLabel = new Intl.DateTimeFormat(locale, {
 		weekday: 'long',
@@ -323,128 +320,23 @@ function Dashboard({
 					</dl>
 				</section>
 
-				<section aria-labelledby="week-heading">
+				<section aria-labelledby="ledger-heading">
 					<div className="mb-4 flex items-baseline justify-between">
 						<h2
-							id="week-heading"
+							id="ledger-heading"
 							className="text-foreground text-lg font-semibold tracking-tight"
 						>
-							This week
+							Session ledger
 						</h2>
 						<Link
 							to="/training/upcoming"
 							className="text-muted-foreground hover:text-foreground text-sm font-medium"
 						>
-							Full ledger →
+							Upcoming →
 						</Link>
 					</div>
 
-					<nav
-						aria-label="Week navigation"
-						className="bg-card border-border/60 overflow-hidden rounded-xl border"
-					>
-						<div className="divide-border/60 grid grid-cols-7 divide-x">
-							{weekDays.map((day) => {
-								const key = isoDayKey(day)
-								const items = sessionsByDay.get(key) ?? []
-								const isToday = key === todayKey
-								const isFocus = key === focusedKey
-								return (
-									<Link
-										key={key}
-										to={dayHref(day)}
-										replace
-										preventScrollReset
-										aria-current={isFocus ? 'date' : undefined}
-										className={cn(
-											'focus-visible:ring-primary/40 flex flex-col gap-1 p-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-inset',
-											isFocus ? 'bg-muted/40' : 'hover:bg-muted/30',
-										)}
-									>
-										<div className="flex items-center justify-between">
-											<span
-												className={cn(
-													'text-xs font-medium tracking-wide uppercase',
-													isToday ? 'text-foreground' : 'text-muted-foreground',
-												)}
-											>
-												{new Intl.DateTimeFormat(locale, {
-													weekday: 'short',
-													timeZone,
-												}).format(day)}
-											</span>
-											<span
-												className={cn(
-													'text-sm tabular-nums',
-													isToday
-														? 'text-foreground font-semibold'
-														: 'text-foreground/70',
-												)}
-											>
-												{day.getDate()}
-											</span>
-										</div>
-										<div className="mt-1 flex flex-wrap gap-1">
-											{items.length === 0 ? (
-												<span className="text-muted-foreground/40 text-xs">
-													·
-												</span>
-											) : (
-												items.map((s) => {
-													const pal = paletteFor(getSessionDiscipline(s))
-													return (
-														<span
-															key={s.id}
-															className={cn('size-2 rounded-full', pal.chip)}
-															title={s.workout?.title ?? 'Recording'}
-														/>
-													)
-												})
-											)}
-										</div>
-										{items[0] ? (
-											<p className="text-foreground/80 mt-1.5 line-clamp-2 text-xs">
-												{items[0].workout?.title ?? 'Recording'}
-											</p>
-										) : null}
-									</Link>
-								)
-							})}
-						</div>
-					</nav>
-
-					{upcomingThisWeek.length > 0 ? (
-						<ul className="mt-4 space-y-2">
-							{upcomingThisWeek.map((s) => {
-								const p = presenter.presentSession(s)
-								const pal = paletteFor(getSessionDiscipline(s))
-								return (
-									<li key={s.id}>
-										<Link
-											to={`/training/upcoming/${s.id}`}
-											className="hover:bg-muted/30 group flex items-center gap-3 rounded-md px-3 py-2 transition"
-										>
-											<span className="text-muted-foreground w-20 shrink-0 text-xs tabular-nums">
-												{p.shortDate}
-											</span>
-											<span
-												className={cn(
-													'size-1.5 shrink-0 rounded-full',
-													pal.chip,
-												)}
-											/>
-											<span className="text-foreground min-w-0 flex-1 truncate text-sm">
-												{s.workout?.title ?? 'Recording'}
-											</span>
-											<span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-												{p.timeOfDay}
-											</span>
-										</Link>
-									</li>
-								)
-							})}
-						</ul>
-					) : null}
+					<SessionLedger sessions={ledger} />
 				</section>
 
 				{recentLogs.length > 0 ? (

--- a/app/routes/_marketing/session-ledger.tsx
+++ b/app/routes/_marketing/session-ledger.tsx
@@ -1,0 +1,346 @@
+import {
+	createColumnHelper,
+	flexRender,
+	getCoreRowModel,
+	useReactTable,
+} from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { type ReactNode, useEffect, useMemo, useRef } from 'react'
+import { Link } from 'react-router'
+import { Icon } from '#app/components/ui/icon.tsx'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '#app/components/ui/table.tsx'
+import { cn } from '#app/utils/misc.tsx'
+import {
+	buildLedgerRows,
+	type LedgerRow,
+	type SessionRow,
+} from '#app/utils/session-ledger-rows.ts'
+import { useSessionPresenter } from '#app/utils/session-presenter.ts'
+import {
+	type ProfileBar,
+	type TrainingZone,
+} from '#app/utils/session-profile.ts'
+import { type LedgerSession } from '#app/utils/training.server.ts'
+import { getDisciplineLabel, type LedgerStatus } from '#app/utils/training.ts'
+
+const ROW_HEIGHT = 44
+
+const columnHelper = createColumnHelper<LedgerRow>()
+
+function session(row: LedgerRow): SessionRow {
+	// Column cells only render for session rows; the "now" divider short-circuits.
+	return row as SessionRow
+}
+
+const columns = [
+	columnHelper.display({
+		id: 'status',
+		header: '',
+		meta: { className: 'w-9 pr-0' },
+		cell: ({ row }) => (
+			<StatusMark status={session(row.original).entry.status} />
+		),
+	}),
+	columnHelper.display({
+		id: 'date',
+		header: 'Date',
+		meta: { className: 'w-28 text-muted-foreground tabular-nums' },
+		cell: ({ row }) => <DateCell session={session(row.original).session} />,
+	}),
+	columnHelper.display({
+		id: 'type',
+		header: 'Type',
+		meta: { className: 'w-20 text-muted-foreground' },
+		cell: ({ row }) =>
+			getDisciplineLabel(session(row.original).entry.discipline),
+	}),
+	columnHelper.display({
+		id: 'session',
+		header: 'Session',
+		meta: { className: 'min-w-0' },
+		cell: ({ row }) => {
+			const r = session(row.original)
+			return (
+				<Link
+					to={`/training/upcoming/${r.id}`}
+					prefetch="intent"
+					className="text-foreground block truncate font-medium hover:underline"
+				>
+					{r.entry.title ??
+						`${getDisciplineLabel(r.entry.discipline)} recording`}
+				</Link>
+			)
+		},
+	}),
+	columnHelper.display({
+		id: 'profile',
+		header: 'Profile',
+		meta: { className: 'w-32' },
+		cell: ({ row }) => <Profile bars={session(row.original).bars} />,
+	}),
+	columnHelper.display({
+		id: 'duration',
+		header: 'Dur',
+		meta: { className: 'w-16 text-right text-muted-foreground tabular-nums' },
+		cell: ({ row }) => {
+			const min = session(row.original).entry.durationMin
+			return min != null ? `${min}m` : '—'
+		},
+	}),
+	columnHelper.display({
+		id: 'load',
+		header: 'Load',
+		meta: { className: 'w-16 text-right text-muted-foreground tabular-nums' },
+		cell: ({ row }) => {
+			const load = session(row.original).entry.load
+			return load != null ? Math.round(load) : '—'
+		},
+	}),
+	columnHelper.display({
+		id: 'rpe',
+		header: 'RPE',
+		meta: { className: 'w-14 text-right text-muted-foreground tabular-nums' },
+		cell: ({ row }) => {
+			const rpe = session(row.original).entry.rpe
+			return rpe != null ? rpe : '—'
+		},
+	}),
+]
+
+export function SessionLedger({
+	sessions,
+	now = new Date(),
+}: {
+	sessions: LedgerSession[]
+	now?: Date
+}) {
+	const rows = useMemo<LedgerRow[]>(
+		() => buildLedgerRows(sessions, now),
+		[sessions, now],
+	)
+
+	const nowIndex = useMemo(
+		() => rows.findIndex((r) => r.kind === 'now'),
+		[rows],
+	)
+
+	const table = useReactTable({
+		data: rows,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		getRowId: (row) => row.id,
+	})
+
+	const scrollRef = useRef<HTMLDivElement>(null)
+	const virtualizer = useVirtualizer({
+		count: rows.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => ROW_HEIGHT,
+		overscan: 10,
+		initialRect: { width: 1024, height: 640 },
+	})
+
+	// Open centered on today: the boundary between past and planned.
+	const didCenter = useRef(false)
+	useEffect(() => {
+		if (didCenter.current || nowIndex < 0) return
+		didCenter.current = true
+		virtualizer.scrollToIndex(nowIndex, { align: 'center' })
+	}, [virtualizer, nowIndex])
+
+	if (sessions.length === 0) {
+		return (
+			<div className="bg-card border-border/60 rounded-xl border p-12 text-center">
+				<p className="text-foreground text-base font-medium">No sessions yet</p>
+				<p className="text-muted-foreground mt-1 text-sm">
+					Plan a session and it will show up on your ledger.
+				</p>
+			</div>
+		)
+	}
+
+	const virtualRows = virtualizer.getVirtualItems()
+	const totalSize = virtualizer.getTotalSize()
+	const paddingTop = virtualRows[0]?.start ?? 0
+	const paddingBottom =
+		virtualRows.length > 0
+			? totalSize - (virtualRows[virtualRows.length - 1]!.end ?? 0)
+			: 0
+	const headerGroup = table.getHeaderGroups()[0]!
+
+	return (
+		<div
+			ref={scrollRef}
+			className="bg-card border-border/60 max-h-[60vh] overflow-auto rounded-xl border"
+		>
+			<Table>
+				<TableHeader className="bg-card sticky top-0 z-10">
+					<TableRow className="hover:bg-transparent">
+						{headerGroup.headers.map((header) => (
+							<TableHead
+								key={header.id}
+								className={cn(
+									'bg-card',
+									(header.column.columnDef.meta as { className?: string })
+										?.className,
+								)}
+							>
+								{flexRender(
+									header.column.columnDef.header,
+									header.getContext(),
+								)}
+							</TableHead>
+						))}
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{paddingTop > 0 ? (
+						<tr aria-hidden style={{ height: paddingTop }}>
+							<td colSpan={columns.length} />
+						</tr>
+					) : null}
+					{virtualRows.map((virtualRow) => {
+						const row = table.getRowModel().rows[virtualRow.index]!
+						if (row.original.kind === 'now') {
+							return <NowMarker key={row.id} colSpan={columns.length} />
+						}
+						const isPast = (row.original as SessionRow).isPast
+						return (
+							<TableRow
+								key={row.id}
+								data-status={(row.original as SessionRow).entry.status}
+								style={{ height: ROW_HEIGHT }}
+								className={cn('text-sm', isPast ? '' : 'text-muted-foreground')}
+							>
+								{row.getVisibleCells().map((cell) => (
+									<TableCell
+										key={cell.id}
+										className={cn(
+											'py-0',
+											(cell.column.columnDef.meta as { className?: string })
+												?.className,
+										)}
+									>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</TableCell>
+								))}
+							</TableRow>
+						)
+					})}
+					{paddingBottom > 0 ? (
+						<tr aria-hidden style={{ height: paddingBottom }}>
+							<td colSpan={columns.length} />
+						</tr>
+					) : null}
+				</TableBody>
+			</Table>
+		</div>
+	)
+}
+
+function NowMarker({ colSpan }: { colSpan: number }) {
+	return (
+		<tr style={{ height: ROW_HEIGHT }} className="bg-background/40">
+			<td colSpan={colSpan} className="px-3">
+				<div className="flex items-center gap-3">
+					<span className="text-primary text-xs font-semibold tracking-wide uppercase">
+						Now
+					</span>
+					<span className="bg-primary/40 h-px flex-1" />
+				</div>
+			</td>
+		</tr>
+	)
+}
+
+const STATUS_MARK: Record<LedgerStatus, { label: string; node: ReactNode }> = {
+	completed: {
+		label: 'Completed',
+		node: <span className="size-2.5 rounded-full bg-emerald-500" />,
+	},
+	planned: {
+		label: 'Planned',
+		node: (
+			<span className="border-muted-foreground/50 size-2.5 rounded-full border-2" />
+		),
+	},
+	missed: {
+		label: 'Missed',
+		node: <Icon name="cross-1" className="text-destructive size-3.5" />,
+	},
+}
+
+function StatusMark({ status }: { status: LedgerStatus }) {
+	const mark = STATUS_MARK[status]
+	return (
+		<span
+			className="flex items-center justify-center"
+			role="img"
+			aria-label={mark.label}
+			title={mark.label}
+		>
+			{mark.node}
+		</span>
+	)
+}
+
+function DateCell({ session: s }: { session: LedgerSession }) {
+	const presenter = useSessionPresenter()
+	const { shortDate } = presenter.presentSession(s)
+	return (
+		<time dateTime={new Date(s.scheduledAt).toISOString()}>{shortDate}</time>
+	)
+}
+
+const ZONE_COLOR: Record<TrainingZone, string> = {
+	1: 'bg-sky-400 dark:bg-sky-500',
+	2: 'bg-emerald-400 dark:bg-emerald-500',
+	3: 'bg-amber-400 dark:bg-amber-500',
+	4: 'bg-orange-500',
+	5: 'bg-rose-500 dark:bg-rose-600',
+}
+
+const ZONE_HEIGHT: Record<TrainingZone, string> = {
+	1: 'h-2',
+	2: 'h-3',
+	3: 'h-4',
+	4: 'h-5',
+	5: 'h-6',
+}
+
+function Profile({ bars }: { bars: ProfileBar[] }) {
+	if (bars.length === 0) {
+		return <span className="text-muted-foreground/60 text-xs">—</span>
+	}
+	const hasDuration = bars.some((b) => b.durationSec > 0)
+	return (
+		<span
+			aria-hidden
+			className="flex h-6 w-full items-end gap-px overflow-hidden"
+		>
+			{bars.map((bar) => (
+				<span
+					key={bar.id}
+					style={
+						hasDuration ? { flexGrow: bar.durationSec || 0.001 } : undefined
+					}
+					className={cn(
+						'block min-w-px rounded-[1px]',
+						hasDuration ? '' : 'flex-1',
+						bar.zone == null
+							? 'bg-muted-foreground/30 h-1.5'
+							: ZONE_COLOR[bar.zone],
+						bar.zone == null ? '' : ZONE_HEIGHT[bar.zone],
+					)}
+				/>
+			))}
+		</span>
+	)
+}

--- a/app/utils/session-ledger-rows.test.ts
+++ b/app/utils/session-ledger-rows.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from 'vitest'
+import { buildLedgerRows, type SessionRow } from './session-ledger-rows.ts'
+import { type LedgerSession } from './training.server.ts'
+
+function makeLedgerSession(
+	overrides: Partial<LedgerSession> = {},
+): LedgerSession {
+	return {
+		id: 'ledger-1',
+		scheduledAt: new Date('2030-01-02T08:00:00.000Z'),
+		status: 'scheduled',
+		tssValue: null,
+		workout: {
+			id: 'workout-1',
+			title: 'Morning Run',
+			description: null,
+			discipline: 'run',
+			intent: 'endurance',
+			blocks: [],
+		},
+		recording: null,
+		sessionLog: null,
+		...overrides,
+	}
+}
+
+const NOW = new Date('2030-01-05T12:00:00.000Z')
+
+test('inserts the now divider between past and planned sessions', () => {
+	const rows = buildLedgerRows(
+		[
+			makeLedgerSession({
+				id: 'past',
+				scheduledAt: new Date('2030-01-03T08:00:00.000Z'),
+				status: 'completed',
+			}),
+			makeLedgerSession({
+				id: 'future',
+				scheduledAt: new Date('2030-01-07T08:00:00.000Z'),
+			}),
+		],
+		NOW,
+	)
+
+	expect(rows.map((r) => r.kind)).toEqual(['session', 'now', 'session'])
+	expect((rows[0] as SessionRow).isPast).toBe(true)
+	expect((rows[2] as SessionRow).isPast).toBe(false)
+})
+
+test('places the now divider at the end when every session is in the past', () => {
+	const rows = buildLedgerRows(
+		[
+			makeLedgerSession({
+				id: 'past-1',
+				scheduledAt: new Date('2030-01-01T08:00:00.000Z'),
+				status: 'completed',
+			}),
+		],
+		NOW,
+	)
+
+	expect(rows.map((r) => r.kind)).toEqual(['session', 'now'])
+})
+
+test('places the now divider first when every session is planned', () => {
+	const rows = buildLedgerRows(
+		[
+			makeLedgerSession({
+				id: 'future-1',
+				scheduledAt: new Date('2030-01-10T08:00:00.000Z'),
+			}),
+		],
+		NOW,
+	)
+
+	expect(rows.map((r) => r.kind)).toEqual(['now', 'session'])
+})
+
+test('maps each session to its normalized ledger entry and profile bars', () => {
+	const rows = buildLedgerRows(
+		[
+			makeLedgerSession({
+				id: 'done',
+				scheduledAt: new Date('2030-01-03T08:00:00.000Z'),
+				status: 'completed',
+				tssValue: 72,
+				sessionLog: { id: 'log-1', rpe: 6 },
+			}),
+		],
+		NOW,
+	)
+
+	const row = rows[0] as SessionRow
+	expect(row.entry.status).toBe('completed')
+	expect(row.entry.load).toBe(72)
+	expect(row.entry.rpe).toBe(6)
+})
+
+test('treats a past session still marked scheduled as missed', () => {
+	const rows = buildLedgerRows(
+		[
+			makeLedgerSession({
+				id: 'skipped',
+				scheduledAt: new Date('2030-01-02T08:00:00.000Z'),
+				status: 'scheduled',
+			}),
+		],
+		NOW,
+	)
+
+	expect((rows[0] as SessionRow).entry.status).toBe('missed')
+})

--- a/app/utils/session-ledger-rows.ts
+++ b/app/utils/session-ledger-rows.ts
@@ -1,0 +1,50 @@
+import {
+	deriveSessionProfile,
+	type ProfileBar,
+} from './session-profile.ts'
+import { type LedgerSession } from './training.server.ts'
+import { type SessionLedgerEntry, toSessionLedgerEntry } from './training.ts'
+
+export type SessionRow = {
+	kind: 'session'
+	id: string
+	session: LedgerSession
+	entry: SessionLedgerEntry
+	bars: ProfileBar[]
+	isPast: boolean
+}
+
+export type NowRow = { kind: 'now'; id: '__now__' }
+
+export type LedgerRow = SessionRow | NowRow
+
+/**
+ * Flatten the chronological session list into renderable rows, inserting a
+ * single "now" divider at the past/planned boundary (the first session not yet
+ * in the past, or at the end when every session is in the past).
+ */
+export function buildLedgerRows(
+	sessions: LedgerSession[],
+	now: Date = new Date(),
+): LedgerRow[] {
+	const nowMs = now.getTime()
+	const rows: LedgerRow[] = []
+	let nowInserted = false
+	for (const s of sessions) {
+		const isPast = new Date(s.scheduledAt).getTime() < nowMs
+		if (!isPast && !nowInserted) {
+			rows.push({ kind: 'now', id: '__now__' })
+			nowInserted = true
+		}
+		rows.push({
+			kind: 'session',
+			id: s.id,
+			session: s,
+			entry: toSessionLedgerEntry(s, now),
+			bars: deriveSessionProfile(s.workout).bars,
+			isPast,
+		})
+	}
+	if (!nowInserted) rows.push({ kind: 'now', id: '__now__' })
+	return rows
+}

--- a/app/utils/session-profile.test.ts
+++ b/app/utils/session-profile.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from 'vitest'
+import { deriveSessionProfile } from './session-profile.ts'
+import { type LedgerSession } from './training.server.ts'
+
+type Workout = NonNullable<LedgerSession['workout']>
+type Step = Workout['blocks'][number]['steps'][number]
+
+function workoutWithBlocks(blocks: Workout['blocks']): Workout {
+	return {
+		id: 'workout-1',
+		title: 'Threshold Intervals',
+		description: null,
+		discipline: 'run',
+		intent: 'threshold',
+		blocks,
+	}
+}
+
+const resolvedNulls = {
+	intensityHrMin: null,
+	intensityHrMax: null,
+	intensityPowerMin: null,
+	intensityPowerMax: null,
+	intensityPaceMin: null,
+	intensityPaceMax: null,
+}
+
+function cardioStep(overrides: Partial<Step> & { id: string }): Step {
+	return {
+		kind: 'cardio',
+		notes: null,
+		discipline: 'run',
+		intensity: null,
+		orderIndex: 0,
+		durationSec: null,
+		distanceM: null,
+		exerciseId: null,
+		restBetweenSetsSec: null,
+		exercise: null,
+		sets: [],
+		...resolvedNulls,
+		...overrides,
+	}
+}
+
+function oneBlock(steps: Step[]): Workout['blocks'] {
+	return [{ id: 'block-1', name: 'Main', orderIndex: 0, repeatCount: 1, steps }]
+}
+
+test('maps the legacy intensity vocabulary to zones', () => {
+	const { bars } = deriveSessionProfile(
+		workoutWithBlocks(
+			oneBlock([
+				cardioStep({ id: 'a', intensity: 'easy', orderIndex: 0 }),
+				cardioStep({ id: 'b', intensity: 'zone2', orderIndex: 1 }),
+				cardioStep({ id: 'c', intensity: 'moderate', orderIndex: 2 }),
+				cardioStep({ id: 'd', intensity: 'threshold', orderIndex: 3 }),
+				cardioStep({ id: 'e', intensity: 'max', orderIndex: 4 }),
+			]),
+		),
+	)
+
+	expect(bars.map((b) => b.zone)).toEqual([1, 2, 3, 4, 5])
+})
+
+test('maps structured zoneLabel targets (Z1–Z7) to zones, clamping above Z5', () => {
+	const { bars } = deriveSessionProfile(
+		workoutWithBlocks(
+			oneBlock([
+				cardioStep({
+					id: 'z3',
+					orderIndex: 0,
+					intensity: JSON.stringify({ kind: 'zoneLabel', label: 'Z3' }),
+				}),
+				cardioStep({
+					id: 'z7',
+					orderIndex: 1,
+					intensity: JSON.stringify({ kind: 'zoneLabel', label: 'Z7' }),
+				}),
+			]),
+		),
+	)
+
+	expect(bars.map((b) => b.zone)).toEqual([3, 5])
+})
+
+test('maps RPE and %FTP power targets to zones', () => {
+	const { bars } = deriveSessionProfile(
+		workoutWithBlocks(
+			oneBlock([
+				cardioStep({
+					id: 'rpe',
+					orderIndex: 0,
+					intensity: JSON.stringify({ kind: 'rpe', min: 3 }),
+				}),
+				cardioStep({
+					id: 'ftp',
+					orderIndex: 1,
+					intensity: JSON.stringify({ kind: 'powerPct', minPct: 95 }),
+				}),
+			]),
+		),
+	)
+
+	expect(bars.map((b) => b.zone)).toEqual([2, 4])
+})
+
+test('leaves unzoneable intensities and non-cardio steps null', () => {
+	const { bars } = deriveSessionProfile(
+		workoutWithBlocks(
+			oneBlock([
+				cardioStep({ id: 'none', orderIndex: 0, intensity: null }),
+				cardioStep({
+					id: 'pace',
+					orderIndex: 1,
+					intensity: JSON.stringify({ kind: 'pace', minSecPerKm: 300 }),
+				}),
+			]),
+		),
+	)
+
+	expect(bars.map((b) => b.zone)).toEqual([null, null])
+})
+
+test('expands block repetition and carries step duration as bar weight', () => {
+	const { bars } = deriveSessionProfile(
+		workoutWithBlocks([
+			{
+				id: 'intervals',
+				name: 'Intervals',
+				orderIndex: 0,
+				repeatCount: 3,
+				steps: [
+					cardioStep({
+						id: 'on',
+						orderIndex: 0,
+						intensity: 'threshold',
+						durationSec: 180,
+					}),
+					cardioStep({
+						id: 'off',
+						orderIndex: 1,
+						intensity: 'easy',
+						durationSec: 60,
+					}),
+				],
+			},
+		]),
+	)
+
+	expect(bars).toHaveLength(6)
+	expect(bars.map((b) => b.zone)).toEqual([4, 1, 4, 1, 4, 1])
+	expect(bars.map((b) => b.durationSec)).toEqual([180, 60, 180, 60, 180, 60])
+})
+
+test('returns no bars for a workout-less session', () => {
+	expect(deriveSessionProfile(null).bars).toEqual([])
+})

--- a/app/utils/session-profile.ts
+++ b/app/utils/session-profile.ts
@@ -1,0 +1,140 @@
+import { type LedgerSession } from './training.server.ts'
+import { IntensityTargetSchema } from './workout-schema.ts'
+
+type Workout = NonNullable<LedgerSession['workout']>
+type WorkoutStep = Workout['blocks'][number]['steps'][number]
+
+/** A normalized training zone, 1 (easiest) through 5 (hardest). */
+export type TrainingZone = 1 | 2 | 3 | 4 | 5
+
+export type ProfileBar = {
+	id: string
+	/** The derived training zone, or null when the step's intensity can't be truthfully mapped to a zone. */
+	zone: TrainingZone | null
+	/** Relative weight for bar width — the step's planned duration in seconds (0 when unquantified). */
+	durationSec: number
+}
+
+export type SessionProfile = {
+	bars: ProfileBar[]
+}
+
+function clampZone(n: number): TrainingZone {
+	if (n <= 1) return 1
+	if (n >= 5) return 5
+	return n as TrainingZone
+}
+
+function zoneLabelToZone(label: string): TrainingZone | null {
+	const normalized = label.trim().toLowerCase()
+	const zMatch = /^z\s*([1-7])$/.exec(normalized)
+	if (zMatch) return clampZone(Number(zMatch[1]))
+	switch (normalized) {
+		case 'recovery':
+		case 'easy':
+			return 1
+		case 'zone2':
+		case 'endurance':
+			return 2
+		case 'moderate':
+		case 'tempo':
+			return 3
+		case 'threshold':
+			return 4
+		case 'vo2max':
+		case 'anaerobic':
+		case 'max':
+			return 5
+		default:
+			return null
+	}
+}
+
+function rpeToZone(min: number): TrainingZone {
+	if (min <= 2) return 1
+	if (min <= 4) return 2
+	if (min <= 6) return 3
+	if (min <= 8) return 4
+	return 5
+}
+
+// Coggan %FTP zones, normalized to threshold so no athlete-specific data is invented.
+function pctToZone(pct: number): TrainingZone {
+	if (pct < 55) return 1
+	if (pct < 76) return 2
+	if (pct < 91) return 3
+	if (pct < 106) return 4
+	return 5
+}
+
+function stepToZone(step: WorkoutStep): TrainingZone | null {
+	if (step.kind !== 'cardio') return null
+	if (!step.intensity) return null
+
+	try {
+		const parsed = IntensityTargetSchema.safeParse(JSON.parse(step.intensity))
+		if (parsed.success) {
+			const t = parsed.data
+			switch (t.kind) {
+				case 'zoneLabel':
+					return zoneLabelToZone(t.label)
+				case 'rpe':
+					return rpeToZone(t.min)
+				case 'powerPct':
+				case 'hrPct':
+					return pctToZone(t.minPct)
+				// hrBpm, power (W) and pace need athlete thresholds to map to a
+				// zone; leaving them unzoned keeps the profile honest.
+				default:
+					return null
+			}
+		}
+	} catch {
+		// fall through to legacy plain-string matching
+	}
+
+	return zoneLabelToZone(step.intensity)
+}
+
+function stepDurationSec(step: WorkoutStep): number {
+	if (step.kind === 'strength') {
+		const setsDuration = step.sets.reduce(
+			(sum, s) =>
+				sum + (s.kind === 'timed' && s.durationSec ? s.durationSec : 0),
+			0,
+		)
+		const restContribution =
+			step.restBetweenSetsSec && step.sets.length > 1
+				? step.restBetweenSetsSec * (step.sets.length - 1)
+				: 0
+		return setsDuration + restContribution
+	}
+	return step.durationSec ?? 0
+}
+
+/**
+ * Derive the per-session intensity profile from a workout's real steps: one bar
+ * per executed step (blocks expanded by repeatCount), colored by training zone
+ * and weighted by Step Duration. Steps whose intensity can't be truthfully
+ * mapped to a zone carry a null zone.
+ */
+export function deriveSessionProfile(workout: Workout | null): SessionProfile {
+	if (!workout) return { bars: [] }
+	const bars = workout.blocks
+		.slice()
+		.sort((a, b) => a.orderIndex - b.orderIndex)
+		.flatMap((block) => {
+			const sortedSteps = block.steps
+				.slice()
+				.sort((a, b) => a.orderIndex - b.orderIndex)
+			return Array.from({ length: block.repeatCount }, (_, repeatIndex) =>
+				sortedSteps.map((step) => ({
+					id:
+						block.repeatCount > 1 ? `${step.id}-r${repeatIndex}` : step.id,
+					zone: stepToZone(step),
+					durationSec: stepDurationSec(step),
+				})),
+			).flat()
+		})
+	return { bars }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "@simplewebauthn/server": "^13.2.2",
         "@tabler/icons-react": "^3.41.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.26",
         "@tusbar/cache-control": "^2.0.0",
         "address": "^2.0.3",
         "bcryptjs": "^3.0.3",
@@ -6989,6 +6991,66 @@
         "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.26",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.26.tgz",
+      "integrity": "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.16.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.16.0.tgz",
+      "integrity": "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "@simplewebauthn/server": "^13.2.2",
     "@tabler/icons-react": "^3.41.1",
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.26",
     "@tusbar/cache-control": "^2.0.0",
     "address": "^2.0.3",
     "bcryptjs": "^3.0.3",


### PR DESCRIPTION
Replace the home week-grid with a dense, virtualized TanStack Table over
the full session ledger (past + planned). Columns: status, date, type,
session, profile, duration, load, RPE. Completed/planned/missed rows are
visually distinct, a "Now" divider separates past from planned, the list
opens centered on today, and the header pins on scroll.

The Profile column is computed from each workout's real step intensities,
mapped to training zones (Z1–Z5) and weighted by step duration.

https://claude.ai/code/session_01NfYvwnyozVG4n6A9znZcj2