### PR TITLE
Keep /training/load as a secondary deep-dive (#62)

### DIFF
--- a/app/routes/_marketing/index.dashboard.test.tsx
+++ b/app/routes/_marketing/index.dashboard.test.tsx
@@ -328,6 +328,18 @@ test('coach card shows readiness label and signed TSB when trustworthy', async (
 	expect(screen.queryByText(/building baseline/i)).not.toBeInTheDocument()
 })
 
+test('coach card links to the load deep-dive', async () => {
+	renderRoute(
+		dashboardLoader(null, [], [], {
+			tsb: 7,
+			tsbTrust: { trustworthy: true, daysOfHistory: 60, requiredDays: 42 },
+		}),
+	)
+
+	const trendLink = await screen.findByRole('link', { name: /load trend/i })
+	expect(trendLink).toHaveAttribute('href', '/training/load')
+})
+
 test('session ledger shows an empty state when there are no sessions', async () => {
 	renderRoute(dashboardLoader(null, [], [], undefined, []))
 

--- a/app/routes/_marketing/index.tsx
+++ b/app/routes/_marketing/index.tsx
@@ -498,6 +498,7 @@ function CoachCard({ tsb, trust }: { tsb: number | null; trust: TsbTrust }) {
 						day {trust.daysOfHistory}/{trust.requiredDays}
 					</span>
 				</div>
+				<CoachCardTrendLink />
 			</section>
 		)
 	}
@@ -541,7 +542,20 @@ function CoachCard({ tsb, trust }: { tsb: number | null; trust: TsbTrust }) {
 			<p className="text-muted-foreground mt-2 text-sm">
 				{readiness.recommendation}
 			</p>
+			<CoachCardTrendLink />
 		</section>
+	)
+}
+
+function CoachCardTrendLink() {
+	return (
+		<Link
+			to="/training/load"
+			prefetch="intent"
+			className="text-muted-foreground hover:text-foreground mt-4 inline-flex items-center gap-1 text-xs font-medium transition-colors"
+		>
+			View load trend →
+		</Link>
 	)
 }
 

--- a/app/routes/training/load.tsx
+++ b/app/routes/training/load.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'react-router'
+import { Link } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import {
 	getCurrentLoad,
@@ -111,8 +111,14 @@ export default function LoadRoute({ loaderData }: Route.ComponentProps) {
 	return (
 		<main className="container py-6 sm:py-10">
 			<header className="border-border/80 bg-card text-card-foreground mb-6 overflow-hidden rounded-4xl border p-5 shadow-md sm:p-6">
-				<p className="text-muted-foreground text-body-2xs font-semibold tracking-[0.18em] uppercase">
-					Training
+				<Link
+					to="/"
+					className="text-muted-foreground hover:text-foreground text-body-2xs inline-flex items-center gap-1 font-medium transition-colors"
+				>
+					← Home
+				</Link>
+				<p className="text-muted-foreground text-body-2xs mt-3 font-semibold tracking-[0.18em] uppercase">
+					Training · Detail
 				</p>
 				<h1 className="font-heading mt-2 text-4xl leading-none font-bold tracking-[-0.04em] sm:text-6xl">
 					Training Load

--- a/docs/adr/0011-retire-load-page-as-deep-dive.md
+++ b/docs/adr/0011-retire-load-page-as-deep-dive.md
@@ -1,0 +1,31 @@
+# `/training/load` kept as a secondary deep-dive, not a primary surface
+
+ADR 0010 resolved that Form (TSB) lives as the Coach card at the top of the home
+page (`/`), with the session ledger below it, and that we are **not** building a
+separate `/training/load` destination as the primary daily surface. With the
+Coach card (#59) and the home session ledger (#60/#61) shipped, the standalone
+three-card `/training/load` page is no longer a primary destination — issue #62
+asked us to decide its fate.
+
+## Decision
+
+Keep `/training/load`, reframed as an optional **secondary deep-dive**, rather
+than deleting it.
+
+Rationale: the page still shows information the home Coach card deliberately
+omits — the full CTL (fitness) / ATL (fatigue) / TSB (form) breakdown and the
+90-day CTL/ATL trend sparkline. The home card surfaces only the single
+plain-language Form reading per ADR 0010; the deep-dive remains the place to
+inspect the underlying load curve. The engine and snapshot data already exist
+(ADR 0010), so retaining a thin read-only view is low cost.
+
+## Consequences
+
+- The home Coach card links to the deep-dive via a low-emphasis
+  "View load trend →" link, in both the cold-start and trustworthy states.
+- `/training/load` stays in the "More" overflow menu, not the primary pill nav;
+  its header is reframed ("Training · Detail" with a "← Home" back link) so it
+  reads as a sub-view of home rather than a primary daily destination.
+- The existing "Full view →" link from `/training/upcoming` continues to work;
+  nothing 404s.
+- Home (`/`) remains the athlete's default destination after login.


### PR DESCRIPTION
Resolves #62. Home is now the primary daily surface (Coach card + ledger),
so /training/load is reframed as an optional deep-dive: the home Coach card
links to it via "View load trend →", and the load page header reads as a
sub-view ("Training · Detail" with a "← Home" back link). It keeps its
unique CTL/ATL breakdown + 90-day trend and stays in the More overflow menu,
so nothing 404s. Decision recorded in ADR 0011.

https://claude.ai/code/session_01Ahi8t1PvMJkR1hRHLrGTsp