### PR TITLE
docs(context): introduce Account Connection for external service links

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -256,6 +256,12 @@ not duplicate them. _Avoid_: Race result row, achievement
   physical session (e.g., a Garmin workout that auto-synced to Strava). The
   model permits this; cross-provider duplicate detection is athlete-driven, not
   automatic. The athlete chooses which to promote and may discard the other.
+- An **Account Connection** can be disconnected. Disconnect stops further
+  syncing and removes non-promoted **Activity Imports** from that provider, but
+  preserves **Recordings** (promoted imports) and their **TSS** contributions
+  to **Training Load** — the athlete's training history remains truthful.
+  Full deletion of historical data (right-to-be-forgotten) is a separate
+  athlete-initiated operation, not part of disconnect.
 - The **Tape** renders **Workout Sessions** as tiles. **Activity Imports** that
   have not been promoted contribute to load metrics but are not Tape tiles.
 - A **Workout Session** may exist with no **Workout** attached when it was

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -152,7 +152,9 @@ discipline filter. _Avoid_: Local filter state, tab state
 training without coach workflows. _Avoid_: Coach-managed athlete, team user
 
 **Authenticated User**: The signed-in identity used for data ownership and
-access control. _Avoid_: Viewer, account
+access control. _Avoid_: Viewer; _avoid bare_ "account" (use **Authenticated
+User** for internal identity, **Account Connection** for an external service
+account)
 
 **Owner**: The authenticated user who owns workouts and workout sessions.
 _Avoid_: Creator, participant
@@ -178,6 +180,13 @@ recommendation. It lives on the home surface, not on a separate Training Load
 page. _Avoid_: TSB widget, form box, readiness card
 
 ### Recording and import
+
+**Account Connection**: An athlete's authorized link to an external training
+service account (Strava, Garmin, Polar) used to exchange training data. One per
+athlete per external account. The external account ID is stored as
+`externalAthleteId`. Manually uploaded Activity Imports use no Account
+Connection. _Avoid_: Integration, Connected Account, Service Connection,
+Provider Connection, Sync Source.
 
 **Activity Import**: A raw telemetry record imported from an external provider
 (Strava, Garmin, manual upload). Stored in an inbox; not rendered on the Tape
@@ -239,6 +248,10 @@ not duplicate them. _Avoid_: Race result row, achievement
 - A **Workout Session** has at most one **Recording**, sourced from an
   **Activity Import**.
 - An **Activity Import** is promoted to at most one **Workout Session**.
+- An **Activity Import** originates from at most one **Account Connection**;
+  manually uploaded imports have none.
+- An **Authenticated User** may have many **Account Connections**, at most one
+  per external service (Strava, Garmin, Polar).
 - The **Tape** renders **Workout Sessions** as tiles. **Activity Imports** that
   have not been promoted contribute to load metrics but are not Tape tiles.
 - A **Workout Session** may exist with no **Workout** attached when it was

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,7 +44,11 @@ group, segment
 discipline, intensity, and quantity. _Avoid_: Interval, action
 
 **Discipline**: The sport modality for a workout or step (run, bike, swim,
-strength). _Avoid_: Activity type, sport type
+strength), with an additional import-only value `other` for Activity Imports
+from external categories the app does not model (hike, yoga, e-bike, alpine
+ski, etc.). Workout Templates and planned Steps cannot use `other`. Activity
+Imports marked `other` do not auto-promote and do not contribute to TSS or
+Training Load. _Avoid_: Activity type, sport type
 
 **Intensity Target**: The prescribed effort level for a step, currently
 expressed via a fixed zone vocabulary (`easy`, `zone2`, `threshold`, `max`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -252,6 +252,10 @@ not duplicate them. _Avoid_: Race result row, achievement
   manually uploaded imports have none.
 - An **Authenticated User** may have many **Account Connections**, at most one
   per external service (Strava, Garmin, Polar).
+- Two **Activity Imports** from different providers may represent the same
+  physical session (e.g., a Garmin workout that auto-synced to Strava). The
+  model permits this; cross-provider duplicate detection is athlete-driven, not
+  automatic. The athlete chooses which to promote and may discard the other.
 - The **Tape** renders **Workout Sessions** as tiles. **Activity Imports** that
   have not been promoted contribute to load metrics but are not Tape tiles.
 - A **Workout Session** may exist with no **Workout** attached when it was

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,9 +188,16 @@ page. _Avoid_: TSB widget, form box, readiness card
 **Account Connection**: An athlete's authorized link to an external training
 service account (Strava, Garmin, Polar) used to exchange training data. One per
 athlete per external account. The external account ID is stored as
-`externalAthleteId`. Manually uploaded Activity Imports use no Account
-Connection. _Avoid_: Integration, Connected Account, Service Connection,
-Provider Connection, Sync Source.
+`externalAthleteId`. Carries a `status`: `active`, `expired`, `revoked`, or
+`error`. `expired` is self-healing via background token refresh and is not
+surfaced to the athlete. `revoked` means the source provider invalidated the
+authorization (athlete deauthorized at source, or refresh permanently failed)
+and requires athlete re-authorization. `error` is reserved for unexpected
+source-side failures requiring triage. Operational sync state (idle / actively
+fetching) is _not_ a `status` value — it is derived from the job queue.
+Manually uploaded Activity Imports use no Account Connection. _Avoid_:
+Integration, Connected Account, Service Connection, Provider Connection, Sync
+Source.
 
 **Backfill Window**: The 42-day historical window of Activity Imports
 retrieved from a newly-connected Account Connection, sized to match the CTL
@@ -273,6 +280,10 @@ not duplicate them. _Avoid_: Race result row, achievement
   to **Training Load** — the athlete's training history remains truthful.
   Full deletion of historical data (right-to-be-forgotten) is a separate
   athlete-initiated operation, not part of disconnect.
+- An **Account Connection** with `status: revoked` is distinct from disconnect:
+  source-initiated revocation stops syncing but does _not_ immediately remove
+  non-promoted Activity Imports — the athlete is given the chance to
+  re-authorize. Only explicit disconnect (or a long timeout) triggers cleanup.
 - **Activity Imports** are snapshots taken at import time. When the source
   provider emits a later `update` for the same activity, non-promoted imports
   refresh to the new snapshot, but promoted **Recordings** are immutable to

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,6 +188,13 @@ athlete per external account. The external account ID is stored as
 Connection. _Avoid_: Integration, Connected Account, Service Connection,
 Provider Connection, Sync Source.
 
+**Backfill Window**: The 42-day historical window of Activity Imports
+retrieved from a newly-connected Account Connection, sized to match the CTL
+window so Training Load is meaningful from day one. Backfill runs as a
+background job (not synchronous with connect) and auto-promotes imports
+without a same-day planned Workout Session to recording-only Workout Sessions.
+_Avoid_: Initial sync, history sync.
+
 **Activity Import**: A raw telemetry record imported from an external provider
 (Strava, Garmin, manual upload). Stored in an inbox; not rendered on the Tape
 directly. Contributes to load metrics independently of Workout Sessions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -273,6 +273,13 @@ not duplicate them. _Avoid_: Race result row, achievement
   to **Training Load** — the athlete's training history remains truthful.
   Full deletion of historical data (right-to-be-forgotten) is a separate
   athlete-initiated operation, not part of disconnect.
+- **Activity Imports** are snapshots taken at import time. When the source
+  provider emits a later `update` for the same activity, non-promoted imports
+  refresh to the new snapshot, but promoted **Recordings** are immutable to
+  source-side changes (the Recording belongs to the athlete's training
+  history). When the source emits a `delete`, non-promoted imports are
+  removed; promoted **Recordings** survive — the same truthfulness rule as
+  Account Connection disconnect.
 - The **Tape** renders **Workout Sessions** as tiles. **Activity Imports** that
   have not been promoted contribute to load metrics but are not Tape tiles.
 - A **Workout Session** may exist with no **Workout** attached when it was

--- a/docs/adr/0012-disconnect-preserves-recordings.md
+++ b/docs/adr/0012-disconnect-preserves-recordings.md
@@ -1,0 +1,64 @@
+# Disconnect preserves Recordings; source-side delete follows the same rule
+
+Trainm8 ingests activities from external training services (Strava first,
+Garmin/Polar later) into an inbox of **Activity Imports**, some of which the
+athlete promotes to **Recordings** attached to a **Workout Session**. Recordings
+carry a **TSS** that contributes to the **Training Load** time series the
+**Coach card** reads. When an athlete disconnects an **Account Connection**, or
+when the source provider emits a `delete` event for a previously imported
+activity, we must decide whether to remove the data from trainm8.
+
+## Decision
+
+Disconnect and source-side `delete` remove only **non-promoted** Activity
+Imports. Promoted **Recordings** survive along with their TSS contributions to
+Training Load. The athlete's training history is treated as truthful and
+immutable to source-side changes.
+
+Source-side `update` events follow the same asymmetry: non-promoted Activity
+Imports refresh to the new snapshot; promoted Recordings are immutable to
+source-side mutations.
+
+A source-initiated `status: revoked` does not immediately remove anything — the
+athlete is given the chance to re-authorize. Only explicit athlete-initiated
+disconnect (or a long quiet timeout, to be calibrated later) triggers cleanup
+of non-promoted imports.
+
+Full deletion of historical data (right-to-be-forgotten) is a separate,
+explicit athlete operation, not part of disconnect.
+
+## Considered options
+
+- **Delete all imports and orphan the Workout Sessions on disconnect**:
+  Rejected — silently re-writes the athlete's Training Load history. CTL/ATL/TSB
+  shift retroactively, Coach card lies about yesterday's form, and Session Logs
+  remain attached to phantom sessions with no telemetry. For a self-coaching
+  athlete whose primary instrument is their own load history, this is the worst
+  possible default.
+- **Keep everything, never clean up**: Rejected — non-promoted imports
+  accumulate forever for athletes who experiment with multiple providers, and
+  no longer represent a viable promotion target once the source connection is
+  gone.
+- **Athlete chooses at disconnect time** ("keep my imports?"): Rejected for
+  V1 — adds a modal to a path that should be a clean exit, and the "keep
+  Recordings, drop inbox" default is the right one for almost every athlete.
+
+## Consequences
+
+- `disconnectAccountConnection()` runs in a transaction:
+  set `status = revoked` or hard-delete the Account Connection row,
+  cascade-delete Activity Imports where `promotedSessionId IS NULL` and
+  `accountConnectionId` matches; leave promoted imports and their Recordings
+  intact. (The promoted import row stays so Recording telemetry remains
+  resolvable.)
+- Strava webhook `delete` events for non-promoted imports cascade-delete the
+  import. `delete` events for promoted imports are a no-op against the
+  Recording but may log a marker for audit.
+- Strava webhook `update` events refresh non-promoted imports in place;
+  promoted imports ignore the update.
+- The disconnect UI explains the rule plainly: "Your Strava activities that
+  have become part of your training history will stay. Items in your import
+  inbox will be removed."
+- A separate "Delete all my Strava data" affordance covers the
+  right-to-be-forgotten path and removes Recordings and Workout Sessions too —
+  with a clear warning that Training Load history will change.

--- a/docs/adr/0013-strava-trigger-model.md
+++ b/docs/adr/0013-strava-trigger-model.md
@@ -1,0 +1,71 @@
+# Activity ingest trigger model: webhook + manual sync + reconciliation poll
+
+For the Strava integration (and future Garmin/Polar integrations), trainm8
+needs to decide how new activities flow from the source provider into our
+**Activity Import** inbox. The trigger model determines whether we need a
+public webhook endpoint, a job runner, polling state, and which UX latency the
+athlete experiences.
+
+## Decision
+
+Use a three-layer hybrid trigger model from V1:
+
+1. **Webhook (primary)** — the source provider POSTs to our public endpoint
+   when activities are created, updated, or deleted. The webhook handler
+   verifies the signature, enqueues a fetch job, and responds within the
+   provider's 2-second timeout. The webhook is a notification only; the
+   activity body is fetched out of band.
+2. **Manual "Sync now" (UX safety valve)** — the athlete can trigger an
+   on-demand sync from the imports UI. Same code path as webhook fetch, but
+   range-scoped by `lastSyncedAt`.
+3. **Reconciliation poll (sweep)** — a sparse scheduled job (daily) walks
+   recent activities for each active Account Connection and creates any
+   imports that were missed (webhook failures, downtime, lost events). Bounded
+   by the provider's per-app rate limit budget.
+
+All three layers feed the same job queue and the same downstream pipeline
+(fetch → create Activity Import → auto-match → SSE push).
+
+## Considered options
+
+- **Manual sync only**: Rejected as the long-term default — fine MVP, but the
+  athlete must remember to click "Sync now" before reflecting on a workout, and
+  shipping a webhook layer later would force a parallel infrastructure rewrite.
+- **Polling only (every 15–30 min)**: Rejected — wastes the provider's
+  per-app rate budget on athletes who haven't trained today, and adds 30 minutes
+  of lag for athletes who have. With Strava's 600/15min cap shared across all
+  Account Connections, frequent polling does not scale.
+- **Webhook only (no reconciliation)**: Rejected — webhooks are not durable.
+  Strava retries a small number of times and gives up. A 10-minute outage can
+  silently drop activities across all athletes. Reconciliation is the safety
+  net.
+- **Synchronous fetch inside the webhook handler**: Rejected — Strava expects
+  a 200 within 2 seconds, and an outbound API call plus DB writes is not
+  reliably within that budget. Decoupling via a queue is the only safe pattern.
+
+## Consequences
+
+- A new job-queue primitive is required. Trainm8 has no job runner today; this
+  ADR commits us to introducing one. The minimum-viable shape is a
+  SQLite-backed table plus a polling worker started from the entry server,
+  scaling to BullMQ or Fly Machines schedules later.
+- A new public route `/webhook/strava` is added. It must verify
+  `X-Strava-Signature` (HMAC-SHA256 of raw body with the webhook signing
+  secret) and reject unsigned requests. `hub.verify_token` is used only at
+  subscription registration time, not on subsequent events.
+- Local dev cannot receive Strava webhooks at `localhost`. An env-conditional
+  path falls back to "manual sync + poll" in development; ngrok or similar is
+  optional for end-to-end webhook testing.
+- Strava webhooks carry only `{ object_id, owner_id, aspect_type }`. Each
+  event triggers a follow-up `GET /activities/:id` call that costs a slot in
+  the per-app 600/15min rate budget. Budgeting / backoff is the worker's job.
+- `Account Connection.lastSyncedAt` is updated by all three triggers and is
+  the high-water mark used by manual sync and reconciliation.
+- The same queue and the same pipeline serve **Backfill Window** jobs on
+  initial connect. One queue, three trigger sources (webhook, manual sync,
+  reconciliation), one job kind (`fetch activity by external id`).
+- Strava access tokens last 6 hours and refresh tokens rotate on each refresh.
+  Token refresh is the worker's responsibility, performed on 401 or
+  proactively before expiry; the new refresh token must be persisted.
+- The reconciliation poll cadence (daily) is a knob we expect to tune once we
+  have data on webhook reliability.

--- a/docs/adr/0014-integrations-per-folder-no-interface.md
+++ b/docs/adr/0014-integrations-per-folder-no-interface.md
@@ -1,0 +1,84 @@
+# Integrations live in per-provider folders; no shared TypeScript interface
+
+Trainm8 will integrate with multiple training-service providers over time
+(Strava in V1, Garmin and Polar planned). The provider-specific work — OAuth
+flow, webhook signature verification, API client, activity mapping — is
+substantial, and a tempting reflex is to design a `TrainingDataProvider`
+interface that all integrations implement. This ADR commits to the opposite
+default.
+
+## Decision
+
+Each provider lives in its own folder under `app/integrations/{provider}/`
+with a stable, conventional file layout. There is **no shared TypeScript
+interface** that providers must implement. The only thing all providers share
+is the output shape they produce: `ActivityImportInput` (already defined in
+`app/utils/activity-import.server.ts`).
+
+The expected per-provider layout:
+
+```
+app/integrations/{provider}/
+  client.server.ts           API wrapper with token refresh
+  oauth.server.ts            OAuth start + callback
+  webhook.server.ts          signature verify + enqueue
+  fetch-activity.server.ts   queue worker: fetch + map to ActivityImportInput
+  discipline-map.ts          provider activity type → Discipline (incl. 'other')
+  types.ts                   provider-native API types (private to the folder)
+```
+
+Provider-specific concerns (OAuth endpoints, scopes, signature algorithm,
+rate-limit headers, paginated fetches, activity-type taxonomy) stay inside
+the folder.
+
+Shared infrastructure lives outside `integrations/`:
+
+- `ActivityImportInput`, `createActivityImport()`, auto-match, promotion, TSS
+  computation, snapshot recompute — already provider-agnostic, must remain so.
+- The job queue (one queue, multiple enqueueing call sites).
+- The SSE channel that pushes "new Activity Import landed" to the browser
+  (one stream, all providers).
+- The `Account Connection` table — `provider` is a string column, not a
+  discriminator the schema enumerates.
+
+## Considered options
+
+- **Define a `TrainingDataProvider` interface in V1**: Rejected. With one
+  implementation, the interface is gambled-against rather than discovered.
+  Strava, Garmin, and Polar have meaningfully different OAuth models, webhook
+  semantics, and rate-limit shapes; the lowest common denominator forces
+  awkward leaks (e.g., "Garmin's webhook subscription is per-user; Strava's
+  is per-app") that break the abstraction's promises anyway. CLAUDE.md
+  explicitly forbids designing for hypothetical requirements.
+- **Adapter pattern with a canonical model layer**: Rejected at this stage —
+  the canonical model is `ActivityImportInput`, which already exists. Adding
+  another transformation layer between "provider native" and
+  `ActivityImportInput` would be the abstraction-for-its-own-sake outcome we
+  are avoiding.
+- **Scatter Strava code across `app/utils/strava-*.ts`**: Rejected. Mixing
+  provider-specific code with shared utilities makes "where does Strava end
+  and trainm8 begin?" answer-by-grep, and adds friction to dropping a new
+  provider folder in place.
+
+## Consequences
+
+- Rule of three: when a third provider lands and a clear cross-provider
+  pattern emerges (e.g., all three OAuth refresh flows have an identical
+  shape), the pattern is extracted to `app/integrations/shared/` rather than
+  retrofit into a top-level interface. Until then, two integrations may
+  contain similar code — that is preferable to a wrong abstraction.
+- Adding a new provider is a copy-the-folder operation: copy
+  `app/integrations/strava/` to `app/integrations/garmin/`, rewrite the
+  contents, register the OAuth route and webhook route, register the
+  discipline mapping. No registry pattern, no plugin loader, no central
+  switch statement that grows with each provider.
+- Provider tests live next to provider code (`*.test.ts` siblings) and import
+  only from that folder plus shared utilities.
+- The Strava-specific discipline mapping table (where `Hike`, `Yoga`, `EBike`
+  collapse to `'other'`) is **not** a global concept — it is private to
+  `app/integrations/strava/discipline-map.ts`. Each provider's mapping is its
+  own.
+- Cross-provider concerns that we may discover later (dedup, conflict
+  resolution, capability matrices for push-to-device) are deliberately out of
+  scope for this ADR. If they materialize, they get their own ADRs and
+  shared modules.

--- a/docs/adr/0015-other-discipline-import-only.md
+++ b/docs/adr/0015-other-discipline-import-only.md
@@ -1,0 +1,79 @@
+# `'other'` Discipline as import-only fifth value
+
+External training services expose far more activity types than trainm8 models.
+Strava alone categorizes ~30 types (`Hike`, `Walk`, `Yoga`, `Crossfit`,
+`EBikeRide`, `AlpineSki`, `RockClimbing`, …). Trainm8's **Discipline**
+vocabulary is `run | bike | swim | strength` — a deliberately tight
+triathlon/multisport scope, with load formulas (ADR 0008) calibrated to it.
+
+When an **Activity Import** arrives that does not map cleanly to one of the
+four canonical Disciplines, we must choose between dropping it, mismapping it
+to the nearest neighbor, expanding the Discipline vocabulary, or assigning it
+to an "other" bucket.
+
+## Decision
+
+Introduce `'other'` as a fifth Discipline value, **import-only**:
+
+- Activity Imports may carry `discipline = 'other'`.
+- **Workout Templates** and planned **Steps** may not — `'other'` is invalid
+  for authoring.
+- Activity Imports marked `'other'` do not auto-promote during Backfill and do
+  not contribute to TSS / Training Load. They appear in the import inbox so
+  the athlete can promote them manually if she wants a record on the Session
+  Ledger.
+- The provider→Discipline mapping table is private to each provider's
+  integration folder (ADR 0014). Anything outside the four-canonical set
+  collapses to `'other'`.
+
+We do **not** expand the Discipline vocabulary with new first-class values
+(`hike`, `nordicSki`, `row`, etc.) in this ADR. That decision is deferred
+until a concrete athlete-profile demand exists.
+
+## Considered options
+
+- **Discard unmodeled activities silently**: Rejected — the athlete sees her
+  Hike in Strava and not in trainm8, with no explanation. Silence is worse
+  than visible-but-non-contributing.
+- **Map to the nearest canonical Discipline (Hike → run, Yoga → strength,
+  EBikeRide → bike)**: Rejected — actively harmful. `rTSS` pace math on a
+  Hike misrepresents stress; bike Coggan TSS on an e-bike is meaningless;
+  yoga is not strength training in any load-relevant sense. CONTEXT.md's
+  Unavailable Metric rule explicitly bans inventing data, and mismapped TSS
+  is invented data flowing straight into CTL/ATL/TSB.
+- **Expand the Discipline vocabulary with new first-class values now**:
+  Rejected as premature. Each new Discipline forces a Load Formula decision
+  (ADR 0008 amendment), Step-authoring UI work, a Discipline Filter slot, a
+  Discipline Allocation row, and ongoing planning UX. Doing this speculatively
+  in the absence of athletes who actually plan hikes/skis is the kind of
+  upfront-flex CLAUDE.md tells us to refuse.
+- **Athlete picks the mapping per import**: Rejected for V1 as default —
+  reasonable as a future opt-in, but unacceptable friction as the only path.
+
+## Consequences
+
+- `Discipline` enum gains the value `'other'`, but Zod / form schemas for
+  Workout Template authoring continue to enforce the four canonical values
+  (run/bike/swim/strength). Validation is split between "input domain" and
+  "import domain".
+- `'other'` Activity Imports are excluded from `autoMatchImport()` — they
+  cannot match a planned Workout Session because no planned Session can have
+  `discipline = 'other'`.
+- `'other'` Activity Imports do not pass the discipline-gated TSS formulas in
+  ADR 0008. The `tssValue` for these imports is `null` (Unavailable Metric),
+  consistent with the existing fallback chain. The LoadSnapshot row for the
+  day still exists; the import does not contribute.
+- The **Discipline Filter** in the Upcoming Ledger does not surface `'other'`
+  as a filter option — it is not a plannable Discipline. The import inbox UI
+  may surface `'other'` distinctly so the athlete can see what was imported
+  but not loaded.
+- A **Discipline Allocation** chart that aggregates upcoming sessions remains
+  unaffected (`'other'` cannot appear there).
+- The provider-side mapping decision for ambiguous activities (e.g., does
+  `EBikeRide` belong in `bike` or `'other'`?) is intentionally local to each
+  provider's `discipline-map.ts`. The default for Strava is `EBikeRide →
+  'other'` because the motor breaks the watts/HR relationship that
+  bike-specific TSS relies on. Future override per athlete is possible but
+  out of scope here.
+- Expanding the Discipline vocabulary later (e.g., adding `hike`) remains an
+  open option but requires its own ADR with a Load Formula decision.


### PR DESCRIPTION
Resolves the naming for the athlete↔external-service relationship that
Strava/Garmin/Polar integrations will need. Refines the Authenticated User
"avoid" rule so bare "account" stays banned while the qualified compound
"Account Connection" is reserved for external service accounts.

https://claude.ai/code/session_019AzRteU5KCVcGr7oD4hNcN