### PR TITLE
fix: unbreak typecheck after base-ui/shadcn upgrade

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -53,4 +53,6 @@ function Button({
 	)
 }
 
-export { Button, buttonVariants }
+type ButtonVariant = VariantProps<typeof buttonVariants>
+
+export { Button, buttonVariants, type ButtonVariant }

--- a/app/routes/_marketing/index.tsx
+++ b/app/routes/_marketing/index.tsx
@@ -707,14 +707,16 @@ function MarketingLanding() {
 								style={{ animationDelay: `${i * 0.07}s` }}
 							>
 								<Tooltip>
-									<TooltipTrigger asChild>
-										<a
-											href={logo.href}
-											className="grid size-20 place-items-center rounded-2xl bg-violet-600/10 p-4 transition hover:-rotate-6 hover:bg-violet-600/15 sm:size-24 dark:bg-violet-200 dark:hover:bg-violet-100"
-										>
-											<img src={logo.src} alt="" />
-										</a>
-									</TooltipTrigger>
+									<TooltipTrigger
+										render={
+											<a
+												href={logo.href}
+												className="grid size-20 place-items-center rounded-2xl bg-violet-600/10 p-4 transition hover:-rotate-6 hover:bg-violet-600/15 sm:size-24 dark:bg-violet-200 dark:hover:bg-violet-100"
+											>
+												<img src={logo.src} alt="" />
+											</a>
+										}
+									/>
 									<TooltipContent>{logo.alt}</TooltipContent>
 								</Tooltip>
 							</li>

--- a/app/routes/settings/profile/connections.tsx
+++ b/app/routes/settings/profile/connections.tsx
@@ -179,21 +179,23 @@ function Connection({
 					<input name="connectionId" value={connection.id} type="hidden" />
 					<TooltipProvider>
 						<Tooltip>
-							<TooltipTrigger asChild>
-								<StatusButton
-									name="intent"
-									value="delete-connection"
-									variant="destructive"
-									size="sm"
-									status={
-										deleteFetcher.state !== 'idle'
-											? 'pending'
-											: (deleteFetcher.data?.status ?? 'idle')
-									}
-								>
-									<Icon name="cross-1" />
-								</StatusButton>
-							</TooltipTrigger>
+							<TooltipTrigger
+								render={
+									<StatusButton
+										name="intent"
+										value="delete-connection"
+										variant="destructive"
+										size="sm"
+										status={
+											deleteFetcher.state !== 'idle'
+												? 'pending'
+												: (deleteFetcher.data?.status ?? 'idle')
+										}
+									>
+										<Icon name="cross-1" />
+									</StatusButton>
+								}
+							/>
 							<TooltipContent>Disconnect this account</TooltipContent>
 						</Tooltip>
 					</TooltipProvider>

--- a/app/routes/training/upcoming.tsx
+++ b/app/routes/training/upcoming.tsx
@@ -366,14 +366,16 @@ function LoadCurve({ snapshots }: { snapshots: LoadSnapshot[] }) {
 					/>
 					{snapshots.map((snap, i) => (
 						<Tooltip key={snap.date}>
-							<TooltipTrigger asChild>
-								<circle
-									cx={xScale(i)}
-									cy={yScale(snap.ctl)}
-									r={4}
-									className="cursor-pointer fill-sky-500"
-								/>
-							</TooltipTrigger>
+							<TooltipTrigger
+								render={
+									<circle
+										cx={xScale(i)}
+										cy={yScale(snap.ctl)}
+										r={4}
+										className="cursor-pointer fill-sky-500"
+									/>
+								}
+							/>
 							<TooltipContent side="top" className="text-xs">
 								<p className="font-semibold">{snap.date}</p>
 								<p>TSS {snap.tssTotal.toFixed(1)}</p>


### PR DESCRIPTION
The dependency bump in f0ab827 regenerated button.tsx without the
ButtonVariant type export and switched Tooltip primitives to base-ui,
which uses `render={<el />}` instead of Radix's `asChild` pattern.

- button.tsx: re-export ButtonVariant (VariantProps of buttonVariants)
- _marketing/index, settings/profile/connections, training/upcoming:
  port the three remaining TooltipTrigger call sites from asChild
  to the render prop.