### PR TITLE
Add Strava OAuth integration with account connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ GITHUB_CLIENT_SECRET="MOCK_GITHUB_CLIENT_SECRET"
 GITHUB_TOKEN="MOCK_GITHUB_TOKEN"
 GITHUB_REDIRECT_URI="https://example.com/auth/github/callback"
 
+# Strava Account Connection (ADR 0014). Leave unset to hide the connect
+# affordance; the mocks rely on the "MOCK_" prefix to avoid hitting real Strava.
+STRAVA_CLIENT_ID="MOCK_STRAVA_CLIENT_ID"
+STRAVA_CLIENT_SECRET="MOCK_STRAVA_CLIENT_SECRET"
+STRAVA_REDIRECT_URI="https://example.com/integrations/strava/callback"
+
 # set this to false to prevent search engines from indexing the website
 # default to allow indexing for seo safety
 ALLOW_INDEXING="true"

--- a/app/integrations/strava/client.server.ts
+++ b/app/integrations/strava/client.server.ts
@@ -1,0 +1,89 @@
+import { type AccountConnection } from '@prisma/client'
+import { prisma } from '#app/utils/db.server.ts'
+import { StravaTokenExchangeError } from './oauth.server.ts'
+import {
+	STRAVA_API_BASE,
+	STRAVA_TOKEN_URL,
+	StravaTokenResponseSchema,
+	type StravaTokenResponse,
+} from './types.ts'
+
+/**
+ * Strava API client with token refresh. Strava access tokens last ~6 hours and
+ * refresh tokens rotate on each refresh (ADR 0013), so the rotated refresh
+ * token must be persisted back onto the Account Connection.
+ *
+ * V1 surface is intentionally small — `getAthlete` plus the refresh primitive.
+ * Activity fetching lands with the ingest pipeline (#72/#73).
+ */
+
+/** A 60s safety margin so we refresh slightly before the real expiry. */
+const EXPIRY_SKEW_MS = 60 * 1000
+
+/** Exchange a refresh token for a fresh access token (rotates the refresh token). */
+export async function refreshStravaToken(
+	refreshToken: string,
+): Promise<StravaTokenResponse> {
+	const response = await fetch(STRAVA_TOKEN_URL, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', accept: 'application/json' },
+		body: JSON.stringify({
+			client_id: process.env.STRAVA_CLIENT_ID,
+			client_secret: process.env.STRAVA_CLIENT_SECRET,
+			refresh_token: refreshToken,
+			grant_type: 'refresh_token',
+		}),
+	})
+	if (!response.ok) {
+		throw new StravaTokenExchangeError(
+			`Strava token refresh failed (${response.status})`,
+			response.status,
+		)
+	}
+	return StravaTokenResponseSchema.parse(await response.json())
+}
+
+/**
+ * Return a valid access token for the connection, refreshing and persisting
+ * rotated tokens when the current one is at/near expiry.
+ */
+export async function getValidAccessToken(
+	connection: Pick<
+		AccountConnection,
+		'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
+	>,
+): Promise<string> {
+	const isExpiring =
+		connection.expiresAt.getTime() - EXPIRY_SKEW_MS <= Date.now()
+	if (!isExpiring) return connection.accessToken
+
+	const refreshed = await refreshStravaToken(connection.refreshToken)
+	await prisma.accountConnection.update({
+		where: { id: connection.id },
+		data: {
+			accessToken: refreshed.access_token,
+			refreshToken: refreshed.refresh_token,
+			expiresAt: new Date(refreshed.expires_at * 1000),
+			status: 'active',
+		},
+	})
+	return refreshed.access_token
+}
+
+/** Authenticated GET against the Strava API, refreshing the token as needed. */
+export async function stravaApiGet<T>(
+	connection: Pick<
+		AccountConnection,
+		'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
+	>,
+	path: string,
+): Promise<T> {
+	const accessToken = await getValidAccessToken(connection)
+	const response = await fetch(`${STRAVA_API_BASE}${path}`, {
+		headers: { Authorization: `Bearer ${accessToken}` },
+	})
+	if (!response.ok) {
+		throw new Error(`Strava API GET ${path} failed (${response.status})`)
+	}
+	return (await response.json()) as T
+}

--- a/app/integrations/strava/client.server.ts
+++ b/app/integrations/strava/client.server.ts
@@ -13,12 +13,72 @@ import {
  * refresh tokens rotate on each refresh (ADR 0013), so the rotated refresh
  * token must be persisted back onto the Account Connection.
  *
- * V1 surface is intentionally small — `getAthlete` plus the refresh primitive.
- * Activity fetching lands with the ingest pipeline (#72/#73).
+ * V1 surface is intentionally small — `stravaApiGet` plus the refresh
+ * primitive, used by the OAuth callback and the manual sync (#72).
  */
 
 /** A 60s safety margin so we refresh slightly before the real expiry. */
 const EXPIRY_SKEW_MS = 60 * 1000
+
+/** The subset of an Account Connection the client needs to make API calls. */
+type ConnectionRef = Pick<
+	AccountConnection,
+	'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
+>
+
+/**
+ * Thrown when Strava permanently rejects the connection's credentials (a 4xx on
+ * refresh). The Account Connection is moved to `revoked`; the athlete must
+ * re-authorize. Callers surface this as a "reconnect" prompt rather than a
+ * transient error.
+ */
+export class StravaConnectionRevokedError extends Error {
+	constructor(message = 'Strava authorization was revoked') {
+		super(message)
+		this.name = 'StravaConnectionRevokedError'
+	}
+}
+
+/** Best-effort move to `revoked`; tolerant of a non-persisted connection ref. */
+async function markConnectionRevoked(id: string): Promise<void> {
+	await prisma.accountConnection
+		.update({ where: { id }, data: { status: 'revoked' } })
+		.catch(() => {})
+}
+
+/**
+ * Refresh the access token and persist the rotated refresh token. A 4xx on
+ * refresh is permanent (the grant was revoked at the source): the connection
+ * moves to `revoked` and we throw `StravaConnectionRevokedError`. Other failures
+ * (5xx, network) propagate so the caller can retry later.
+ */
+async function refreshAndPersist(connection: ConnectionRef): Promise<string> {
+	let refreshed: StravaTokenResponse
+	try {
+		refreshed = await refreshStravaToken(connection.refreshToken)
+	} catch (err) {
+		if (
+			err instanceof StravaTokenExchangeError &&
+			err.status != null &&
+			err.status >= 400 &&
+			err.status < 500
+		) {
+			await markConnectionRevoked(connection.id)
+			throw new StravaConnectionRevokedError()
+		}
+		throw err
+	}
+	await prisma.accountConnection.update({
+		where: { id: connection.id },
+		data: {
+			accessToken: refreshed.access_token,
+			refreshToken: refreshed.refresh_token,
+			expiresAt: new Date(refreshed.expires_at * 1000),
+			status: 'active',
+		},
+	})
+	return refreshed.access_token
+}
 
 /** Exchange a refresh token for a fresh access token (rotates the refresh token). */
 export async function refreshStravaToken(
@@ -48,40 +108,37 @@ export async function refreshStravaToken(
  * rotated tokens when the current one is at/near expiry.
  */
 export async function getValidAccessToken(
-	connection: Pick<
-		AccountConnection,
-		'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
-	>,
+	connection: ConnectionRef,
 ): Promise<string> {
 	const isExpiring =
 		connection.expiresAt.getTime() - EXPIRY_SKEW_MS <= Date.now()
 	if (!isExpiring) return connection.accessToken
-
-	const refreshed = await refreshStravaToken(connection.refreshToken)
-	await prisma.accountConnection.update({
-		where: { id: connection.id },
-		data: {
-			accessToken: refreshed.access_token,
-			refreshToken: refreshed.refresh_token,
-			expiresAt: new Date(refreshed.expires_at * 1000),
-			status: 'active',
-		},
-	})
-	return refreshed.access_token
+	return refreshAndPersist(connection)
 }
 
-/** Authenticated GET against the Strava API, refreshing the token as needed. */
+/**
+ * Authenticated GET against the Strava API. Refreshes proactively when the
+ * stored token is near expiry, and reactively retries once on a 401 (the token
+ * was rejected despite looking valid). A permanent refresh failure surfaces as
+ * `StravaConnectionRevokedError`.
+ */
 export async function stravaApiGet<T>(
-	connection: Pick<
-		AccountConnection,
-		'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
-	>,
+	connection: ConnectionRef,
 	path: string,
 ): Promise<T> {
+	const url = `${STRAVA_API_BASE}${path}`
 	const accessToken = await getValidAccessToken(connection)
-	const response = await fetch(`${STRAVA_API_BASE}${path}`, {
+	let response = await fetch(url, {
 		headers: { Authorization: `Bearer ${accessToken}` },
 	})
+
+	if (response.status === 401) {
+		const refreshedToken = await refreshAndPersist(connection)
+		response = await fetch(url, {
+			headers: { Authorization: `Bearer ${refreshedToken}` },
+		})
+	}
+
 	if (!response.ok) {
 		throw new Error(`Strava API GET ${path} failed (${response.status})`)
 	}

--- a/app/integrations/strava/discipline-map.test.ts
+++ b/app/integrations/strava/discipline-map.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { stravaTypeToDiscipline } from './discipline-map.ts'
+
+test('maps modeled Strava types to disciplines', () => {
+	expect(stravaTypeToDiscipline('Run')).toBe('run')
+	expect(stravaTypeToDiscipline('TrailRun')).toBe('run')
+	expect(stravaTypeToDiscipline('Ride')).toBe('bike')
+	expect(stravaTypeToDiscipline('MountainBikeRide')).toBe('bike')
+	expect(stravaTypeToDiscipline('Swim')).toBe('swim')
+	expect(stravaTypeToDiscipline('WeightTraining')).toBe('strength')
+})
+
+test('collapses unmodeled types to "other"', () => {
+	// Hike, Yoga, EBike etc. are not modeled disciplines (CONTEXT.md).
+	expect(stravaTypeToDiscipline('Hike')).toBe('other')
+	expect(stravaTypeToDiscipline('Yoga')).toBe('other')
+	expect(stravaTypeToDiscipline('EBikeRide')).toBe('other')
+	expect(stravaTypeToDiscipline('AlpineSki')).toBe('other')
+	expect(stravaTypeToDiscipline('SomethingBrandNew')).toBe('other')
+})

--- a/app/integrations/strava/discipline-map.ts
+++ b/app/integrations/strava/discipline-map.ts
@@ -1,0 +1,42 @@
+/**
+ * Maps a Strava activity type to a trainm8 Discipline. This table is private to
+ * the Strava integration (ADR 0014) — each provider owns its own mapping.
+ *
+ * Anything trainm8 does not model as a first-class discipline collapses to
+ * `'other'` (CONTEXT.md): hikes, yoga, e-bike rides, alpine ski, etc. Imports
+ * marked `'other'` do not auto-promote and do not contribute to TSS or Training
+ * Load.
+ *
+ * Strava activity `type`/`sport_type` reference:
+ * https://developers.strava.com/docs/reference/#api-models-ActivityType
+ */
+export type Discipline = 'run' | 'bike' | 'swim' | 'strength' | 'other'
+
+const STRAVA_TYPE_TO_DISCIPLINE: Record<string, Discipline> = {
+	// Run family
+	Run: 'run',
+	TrailRun: 'run',
+	VirtualRun: 'run',
+
+	// Bike family (real, modeled rides; EBike is intentionally 'other')
+	Ride: 'bike',
+	GravelRide: 'bike',
+	MountainBikeRide: 'bike',
+	VirtualRide: 'bike',
+
+	// Swim
+	Swim: 'swim',
+
+	// Strength
+	WeightTraining: 'strength',
+	Workout: 'strength',
+	Crossfit: 'strength',
+}
+
+/**
+ * Resolve a Strava `sport_type` (preferred) or legacy `type` to a Discipline.
+ * Unknown or unmodeled types fall back to `'other'`.
+ */
+export function stravaTypeToDiscipline(stravaType: string): Discipline {
+	return STRAVA_TYPE_TO_DISCIPLINE[stravaType] ?? 'other'
+}

--- a/app/integrations/strava/oauth.server.ts
+++ b/app/integrations/strava/oauth.server.ts
@@ -1,0 +1,118 @@
+import { createId as cuid } from '@paralleldrive/cuid2'
+import * as cookie from 'cookie'
+import {
+	STRAVA_AUTHORIZE_URL,
+	STRAVA_SCOPE,
+	STRAVA_TOKEN_URL,
+	StravaTokenResponseSchema,
+	type StravaTokenResponse,
+} from './types.ts'
+
+/** httpOnly cookie that carries the CSRF state across the OAuth round-trip. */
+export const STRAVA_OAUTH_STATE_COOKIE = 'strava_oauth_state'
+
+/** True when the Strava OAuth app credentials are configured. */
+export function isStravaOAuthConfigured() {
+	return Boolean(
+		process.env.STRAVA_CLIENT_ID &&
+			process.env.STRAVA_CLIENT_SECRET &&
+			process.env.STRAVA_REDIRECT_URI,
+	)
+}
+
+/** Thrown when exchanging the authorization code with Strava fails. */
+export class StravaTokenExchangeError extends Error {
+	constructor(
+		message: string,
+		readonly status?: number,
+	) {
+		super(message)
+		this.name = 'StravaTokenExchangeError'
+	}
+}
+
+/**
+ * Build the Strava authorize URL and the matching state cookie. The caller
+ * redirects to `url` after setting `setCookie`; the callback compares the
+ * returned `state` query param against this cookie (CSRF protection).
+ */
+export function buildStravaAuthorization() {
+	const state = cuid()
+	const params = new URLSearchParams({
+		client_id: process.env.STRAVA_CLIENT_ID ?? '',
+		redirect_uri: process.env.STRAVA_REDIRECT_URI ?? '',
+		response_type: 'code',
+		approval_prompt: 'auto',
+		scope: STRAVA_SCOPE,
+		state,
+	})
+	const setCookie = cookie.serialize(STRAVA_OAUTH_STATE_COOKIE, state, {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'lax',
+		maxAge: 60 * 10,
+		secure: process.env.NODE_ENV === 'production',
+	})
+	return { url: `${STRAVA_AUTHORIZE_URL}?${params.toString()}`, setCookie, state }
+}
+
+/** Read the CSRF state previously stored in the request's cookie. */
+export function getStravaOAuthState(request: Request) {
+	const header = request.headers.get('cookie')
+	if (!header) return null
+	return cookie.parse(header)[STRAVA_OAUTH_STATE_COOKIE] ?? null
+}
+
+/** Clear the state cookie once the round-trip completes. */
+export const destroyStravaOAuthStateCookie = cookie.serialize(
+	STRAVA_OAUTH_STATE_COOKIE,
+	'',
+	{ path: '/', maxAge: -1 },
+)
+
+/**
+ * Constant-time-ish comparison guarding against an empty/forged state. Both the
+ * cookie value and the query value must be present and equal.
+ */
+export function verifyStravaOAuthState(
+	cookieState: string | null,
+	queryState: string | null,
+): boolean {
+	return Boolean(cookieState && queryState && cookieState === queryState)
+}
+
+/**
+ * Exchange an authorization code for tokens. Strava returns the athlete summary
+ * inline, so the callback need not make a follow-up `/athlete` request.
+ */
+export async function exchangeStravaCode(
+	code: string,
+): Promise<StravaTokenResponse> {
+	const response = await fetch(STRAVA_TOKEN_URL, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			accept: 'application/json',
+		},
+		body: JSON.stringify({
+			client_id: process.env.STRAVA_CLIENT_ID,
+			client_secret: process.env.STRAVA_CLIENT_SECRET,
+			code,
+			grant_type: 'authorization_code',
+		}),
+	})
+
+	if (!response.ok) {
+		throw new StravaTokenExchangeError(
+			`Strava token exchange failed (${response.status})`,
+			response.status,
+		)
+	}
+
+	return StravaTokenResponseSchema.parse(await response.json())
+}
+
+/** Convert Strava's Unix-seconds `expires_at` to a Date. */
+export function stravaExpiresAtToDate(expiresAt: number): Date {
+	return new Date(expiresAt * 1000)
+}

--- a/app/integrations/strava/oauth.server.ts
+++ b/app/integrations/strava/oauth.server.ts
@@ -15,8 +15,8 @@ export const STRAVA_OAUTH_STATE_COOKIE = 'strava_oauth_state'
 export function isStravaOAuthConfigured() {
 	return Boolean(
 		process.env.STRAVA_CLIENT_ID &&
-			process.env.STRAVA_CLIENT_SECRET &&
-			process.env.STRAVA_REDIRECT_URI,
+		process.env.STRAVA_CLIENT_SECRET &&
+		process.env.STRAVA_REDIRECT_URI,
 	)
 }
 
@@ -53,7 +53,11 @@ export function buildStravaAuthorization() {
 		maxAge: 60 * 10,
 		secure: process.env.NODE_ENV === 'production',
 	})
-	return { url: `${STRAVA_AUTHORIZE_URL}?${params.toString()}`, setCookie, state }
+	return {
+		url: `${STRAVA_AUTHORIZE_URL}?${params.toString()}`,
+		setCookie,
+		state,
+	}
 }
 
 /** Read the CSRF state previously stored in the request's cookie. */
@@ -71,8 +75,10 @@ export const destroyStravaOAuthStateCookie = cookie.serialize(
 )
 
 /**
- * Constant-time-ish comparison guarding against an empty/forged state. Both the
- * cookie value and the query value must be present and equal.
+ * Guard against an empty or forged state: the cookie value and the returned
+ * query value must both be present and equal. A plain equality check is
+ * sufficient here — both values originate from the same request and the cookie
+ * is httpOnly, so timing-attack resistance is not a concern.
  */
 export function verifyStravaOAuthState(
 	cookieState: string | null,

--- a/app/integrations/strava/sync.server.test.ts
+++ b/app/integrations/strava/sync.server.test.ts
@@ -1,0 +1,218 @@
+import { invariant } from '@epic-web/invariant'
+import { faker } from '@faker-js/faker'
+import { http, HttpResponse } from 'msw'
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { server } from '#tests/mocks/index.ts'
+import { syncStravaActivities } from './sync.server.ts'
+
+const ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities'
+const TOKEN_URL = 'https://www.strava.com/oauth/token'
+
+async function setupConnection(
+	overrides: Partial<{
+		accessToken: string
+		refreshToken: string
+		expiresAt: Date
+		status: string
+		lastSyncedAt: Date | null
+	}> = {},
+) {
+	const user = await prisma.user.create({
+		data: { ...createUser() },
+		select: { id: true },
+	})
+	const connection = await prisma.accountConnection.create({
+		data: {
+			athleteId: user.id,
+			provider: 'strava',
+			externalAthleteId: '12345678',
+			accessToken: overrides.accessToken ?? 'initial_access',
+			refreshToken: overrides.refreshToken ?? 'initial_refresh',
+			expiresAt: overrides.expiresAt ?? new Date(Date.now() + 6 * 60 * 60 * 1000),
+			status: overrides.status ?? 'active',
+			connectedAt: new Date('2026-05-01T00:00:00.000Z'),
+			lastSyncedAt: overrides.lastSyncedAt ?? null,
+		},
+	})
+	return { user, connection }
+}
+
+async function createRunWorkout(userId: string) {
+	return prisma.workout.create({
+		select: { id: true },
+		data: {
+			title: faker.lorem.words(3),
+			discipline: 'run',
+			intent: 'endurance',
+			ownerId: userId,
+		},
+	})
+}
+
+test('happy path: imports activities across disciplines including "other"', async () => {
+	const { user, connection } = await setupConnection()
+
+	const result = await syncStravaActivities(user.id)
+
+	invariant(result.ok, 'expected a successful sync')
+	expect(result.created).toBe(4)
+
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+		orderBy: { externalId: 'asc' },
+	})
+	expect(imports).toHaveLength(4)
+	expect(imports.map((i) => i.discipline).sort()).toEqual([
+		'bike',
+		'other',
+		'run',
+		'swim',
+	])
+	expect(imports.every((i) => i.externalProvider === 'strava')).toBe(true)
+
+	// Field mapping for the run: 10km in 3000s → 300 s/km pace.
+	const run = imports.find((i) => i.discipline === 'run')!
+	expect(run.distanceM).toBe(10000)
+	expect(run.durationSec).toBe(3000)
+	expect(run.paceAvgSecPerKm).toBe(300)
+	expect(run.hrAvg).toBe(150)
+	expect(run.polyline).toBe('abc')
+
+	// lastSyncedAt advances on success.
+	const after = await prisma.accountConnection.findUnique({
+		where: { id: connection.id },
+	})
+	expect(after!.lastSyncedAt).not.toBeNull()
+})
+
+test('re-sync is idempotent: duplicates are skipped, not re-imported', async () => {
+	const { user } = await setupConnection()
+
+	await syncStravaActivities(user.id)
+	const second = await syncStravaActivities(user.id)
+
+	invariant(second.ok, 'expected a successful re-sync')
+	expect(second.created).toBe(0)
+	expect(second.skipped).toBe(4)
+
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(4)
+})
+
+test('auto-matches modeled disciplines but excludes "other"', async () => {
+	const { user } = await setupConnection()
+	const workout = await createRunWorkout(user.id)
+	// Planned run on the same UTC day as the mock "Morning Run" (2026-05-20).
+	await prisma.workoutSession.create({
+		data: {
+			userId: user.id,
+			workoutId: workout.id,
+			scheduledAt: new Date('2026-05-20T09:00:00.000Z'),
+		},
+	})
+
+	await syncStravaActivities(user.id)
+
+	const run = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, discipline: 'run' },
+	})
+	expect(run!.promotedSessionId).not.toBeNull()
+
+	const other = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, discipline: 'other' },
+	})
+	expect(other!.promotedSessionId).toBeNull()
+	expect(other!.tssValue).toBeNull()
+})
+
+test('reactively refreshes and retries once on a 401', async () => {
+	const { user, connection } = await setupConnection({
+		refreshToken: 'initial_refresh',
+	})
+
+	let calls = 0
+	server.use(
+		http.get(ACTIVITIES_URL, () => {
+			calls++
+			if (calls === 1) return new HttpResponse(null, { status: 401 })
+			return HttpResponse.json([
+				{
+					id: 2001,
+					sport_type: 'Run',
+					type: 'Run',
+					distance: 5000,
+					moving_time: 1500,
+					elapsed_time: 1500,
+					start_date: '2026-05-20T06:00:00Z',
+				},
+			])
+		}),
+	)
+
+	const result = await syncStravaActivities(user.id)
+
+	invariant(result.ok, 'expected a successful sync after refresh')
+	expect(result.created).toBe(1)
+	expect(calls).toBe(2)
+
+	// The rotated refresh token (from the default token mock) is persisted.
+	const after = await prisma.accountConnection.findUnique({
+		where: { id: connection.id },
+	})
+	expect(after!.refreshToken).toBe('mock_refresh_token')
+	expect(after!.refreshToken).not.toBe('initial_refresh')
+})
+
+test('a permanent refresh failure moves the connection to revoked', async () => {
+	const { user, connection } = await setupConnection({
+		// Expired access token forces a proactive refresh.
+		expiresAt: new Date(Date.now() - 1000),
+	})
+	server.use(
+		http.post(TOKEN_URL, () =>
+			HttpResponse.json({ message: 'invalid' }, { status: 400 }),
+		),
+	)
+
+	const result = await syncStravaActivities(user.id)
+
+	expect(result).toEqual({ ok: false, reason: 'revoked' })
+
+	const after = await prisma.accountConnection.findUnique({
+		where: { id: connection.id },
+	})
+	expect(after!.status).toBe('revoked')
+	// No watermark advance, no imports created.
+	expect(after!.lastSyncedAt).toBeNull()
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(0)
+})
+
+test('returns not-connected when the athlete has no Strava connection', async () => {
+	const user = await prisma.user.create({
+		data: { ...createUser() },
+		select: { id: true },
+	})
+
+	const result = await syncStravaActivities(user.id)
+
+	expect(result).toEqual({ ok: false, reason: 'not-connected' })
+})
+
+test('refuses to sync a revoked connection', async () => {
+	const { user } = await setupConnection({ status: 'revoked' })
+
+	const result = await syncStravaActivities(user.id)
+
+	expect(result).toEqual({ ok: false, reason: 'revoked' })
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(0)
+})

--- a/app/integrations/strava/sync.server.ts
+++ b/app/integrations/strava/sync.server.ts
@@ -1,0 +1,146 @@
+import {
+	autoMatchImport,
+	createActivityImport,
+} from '#app/utils/activity-import.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { stravaApiGet, StravaConnectionRevokedError } from './client.server.ts'
+import { stravaTypeToDiscipline } from './discipline-map.ts'
+import {
+	STRAVA_PROVIDER,
+	StravaActivitiesSchema,
+	type StravaActivity,
+} from './types.ts'
+
+/**
+ * Manual "Sync now" (#72). Fetches the athlete's Strava activities created since
+ * the last successful sync (or since the connection was made on first sync) and
+ * files each one as an `ActivityImport` in the inbox. Strava activity types are
+ * mapped to disciplines via the provider-private table (ADR 0014); unmodeled
+ * types collapse to `'other'` (ADR 0015) and are excluded from auto-match.
+ *
+ * Token refresh — including the rotated refresh token — is handled transparently
+ * by the API client. A permanently revoked grant surfaces as a `revoked` result
+ * so the surface can prompt the athlete to re-authorize.
+ */
+
+/** Strava caps `per_page` at 200; a modest page size keeps each request small. */
+const PER_PAGE = 100
+/** Safety cap so a misbehaving cursor can never loop forever. */
+const MAX_PAGES = 20
+
+export type StravaSyncResult =
+	| { ok: true; created: number; skipped: number }
+	| { ok: false; reason: 'not-connected' | 'revoked' }
+
+export async function syncStravaActivities(
+	athleteId: string,
+): Promise<StravaSyncResult> {
+	const connection = await prisma.accountConnection.findUnique({
+		where: { athleteId_provider: { athleteId, provider: STRAVA_PROVIDER } },
+	})
+	if (!connection) return { ok: false, reason: 'not-connected' }
+	if (connection.status === 'revoked') return { ok: false, reason: 'revoked' }
+
+	// First sync reaches back to when the athlete connected; later syncs only
+	// pull what's new since the previous successful run.
+	const since = connection.lastSyncedAt ?? connection.connectedAt
+	const after = Math.floor(since.getTime() / 1000)
+
+	const timezone =
+		(
+			await prisma.athleteProfile.findUnique({
+				where: { userId: athleteId },
+				select: { timezone: true },
+			})
+		)?.timezone ?? 'UTC'
+
+	let created = 0
+	let skipped = 0
+	try {
+		for (let page = 1; page <= MAX_PAGES; page++) {
+			const activities = StravaActivitiesSchema.parse(
+				await stravaApiGet(
+					connection,
+					`/athlete/activities?after=${after}&per_page=${PER_PAGE}&page=${page}`,
+				),
+			)
+			if (activities.length === 0) break
+
+			for (const activity of activities) {
+				const outcome = await importStravaActivity(athleteId, activity, timezone)
+				if (outcome === 'created') created++
+				else skipped++
+			}
+
+			// A short page means we've reached the end of the cursor.
+			if (activities.length < PER_PAGE) break
+		}
+	} catch (err) {
+		if (err instanceof StravaConnectionRevokedError) {
+			return { ok: false, reason: 'revoked' }
+		}
+		throw err
+	}
+
+	// Only advance the watermark on a fully successful pass.
+	await prisma.accountConnection.update({
+		where: { id: connection.id },
+		data: { lastSyncedAt: new Date() },
+	})
+
+	return { ok: true, created, skipped }
+}
+
+/**
+ * Turn one Strava activity into an `ActivityImport`. Returns `'skipped'` when the
+ * activity was already imported (the unique `(provider, externalId)` guard makes
+ * re-syncs idempotent), otherwise `'created'`.
+ */
+async function importStravaActivity(
+	athleteId: string,
+	activity: StravaActivity,
+	timezone: string,
+): Promise<'created' | 'skipped'> {
+	const discipline = stravaTypeToDiscipline(
+		activity.sport_type ?? activity.type ?? '',
+	)
+	const startedAt = new Date(activity.start_date)
+	const durationSec = activity.moving_time ?? activity.elapsed_time ?? 0
+	const elapsedSec = activity.elapsed_time ?? durationSec
+	const endedAt = new Date(startedAt.getTime() + elapsedSec * 1000)
+	const distanceM = activity.distance ?? null
+	const paceAvgSecPerKm =
+		distanceM != null && distanceM > 0 && durationSec > 0
+			? durationSec / (distanceM / 1000)
+			: null
+
+	let importRecord: { id: string }
+	try {
+		importRecord = await createActivityImport(athleteId, {
+			externalProvider: 'strava',
+			externalId: activity.id,
+			startedAt,
+			endedAt,
+			durationSec,
+			distanceM,
+			discipline,
+			hrAvg: activity.average_heartrate ?? null,
+			powerAvg: activity.average_watts ?? null,
+			paceAvgSecPerKm,
+			polyline: activity.map?.summary_polyline ?? null,
+			rawJson: JSON.stringify(activity),
+		})
+	} catch (err) {
+		if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
+			return 'skipped'
+		}
+		throw err
+	}
+
+	// 'other' imports are excluded from auto-match (ADR 0015); they wait in the
+	// inbox for the athlete to handle manually.
+	if (discipline !== 'other') {
+		await autoMatchImport(athleteId, importRecord.id, timezone)
+	}
+	return 'created'
+}

--- a/app/integrations/strava/types.ts
+++ b/app/integrations/strava/types.ts
@@ -38,3 +38,27 @@ export const StravaTokenResponseSchema = z.object({
 	athlete: StravaAthleteSchema.optional(),
 })
 export type StravaTokenResponse = z.infer<typeof StravaTokenResponseSchema>
+
+/**
+ * A Strava summary activity as returned by `GET /athlete/activities`. We only
+ * model the fields the ingest pipeline maps onto an `ActivityImport`; unknown
+ * fields are ignored and preserved verbatim in `rawJson`. `sport_type` is the
+ * modern field (preferred); `type` is the legacy fallback. Distances are in
+ * metres and times in seconds; `start_date` is an ISO-8601 UTC timestamp.
+ */
+export const StravaActivitySchema = z.object({
+	id: z.union([z.number(), z.string()]).transform((id) => String(id)),
+	name: z.string().nullish(),
+	distance: z.number().nullish(),
+	moving_time: z.number().nullish(),
+	elapsed_time: z.number().nullish(),
+	type: z.string().nullish(),
+	sport_type: z.string().nullish(),
+	start_date: z.string(),
+	average_heartrate: z.number().nullish(),
+	average_watts: z.number().nullish(),
+	map: z.object({ summary_polyline: z.string().nullish() }).nullish(),
+})
+export type StravaActivity = z.infer<typeof StravaActivitySchema>
+
+export const StravaActivitiesSchema = z.array(StravaActivitySchema)

--- a/app/integrations/strava/types.ts
+++ b/app/integrations/strava/types.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+/**
+ * Strava-native API types and parse schemas. Private to the Strava integration
+ * folder (ADR 0014) — nothing outside `app/integrations/strava/` should import
+ * these; the rest of the app speaks `ActivityImportInput` and the shared
+ * `AccountConnection` model.
+ */
+
+export const STRAVA_PROVIDER = 'strava' as const
+
+/** Scope required to read all of an athlete's activities (incl. private). */
+export const STRAVA_SCOPE = 'activity:read_all'
+
+export const STRAVA_AUTHORIZE_URL = 'https://www.strava.com/oauth/authorize'
+export const STRAVA_TOKEN_URL = 'https://www.strava.com/oauth/token'
+export const STRAVA_API_BASE = 'https://www.strava.com/api/v3'
+
+/** The athlete summary Strava returns alongside a token exchange. */
+export const StravaAthleteSchema = z.object({
+	id: z.union([z.number(), z.string()]).transform((id) => String(id)),
+	username: z.string().nullish(),
+	firstname: z.string().nullish(),
+	lastname: z.string().nullish(),
+})
+export type StravaAthlete = z.infer<typeof StravaAthleteSchema>
+
+/**
+ * Strava's `/oauth/token` response. `expires_at` is a Unix timestamp in
+ * seconds; refresh tokens rotate on each refresh and must be persisted
+ * (ADR 0013).
+ */
+export const StravaTokenResponseSchema = z.object({
+	access_token: z.string(),
+	refresh_token: z.string(),
+	expires_at: z.number(),
+	token_type: z.string().optional(),
+	athlete: StravaAthleteSchema.optional(),
+})
+export type StravaTokenResponse = z.infer<typeof StravaTokenResponseSchema>

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { Form, Link } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { Badge } from '#app/components/ui/badge.tsx'
 import { Button, buttonVariants } from '#app/components/ui/button.tsx'
@@ -9,12 +9,15 @@ import {
 	CardHeader,
 	CardTitle,
 } from '#app/components/ui/card.tsx'
-import { requireUserId } from '#app/utils/auth.server.ts'
+import { isStravaOAuthConfigured } from '#app/integrations/strava/oauth.server.ts'
+import { STRAVA_PROVIDER } from '#app/integrations/strava/types.ts'
+import { getAccountConnection } from '#app/utils/account-connection.server.ts'
 import {
 	getInboxImports,
 	unlinkImport,
 	type InboxImport,
 } from '#app/utils/activity-import.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
 import { getDisciplineLabel } from '#app/utils/training.ts'
 import {
 	formatDuration,
@@ -28,8 +31,17 @@ export const meta: Route.MetaFunction = () => [
 
 export async function loader({ request }: Route.LoaderArgs) {
 	const userId = await requireUserId(request)
-	const imports = await getInboxImports(userId)
-	return { imports }
+	const [imports, stravaConnection] = await Promise.all([
+		getInboxImports(userId),
+		getAccountConnection(userId, STRAVA_PROVIDER),
+	])
+	return {
+		imports,
+		strava: {
+			configured: isStravaOAuthConfigured(),
+			connected: stravaConnection?.status === 'active',
+		},
+	}
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -48,7 +60,7 @@ export async function action({ request }: Route.ActionArgs) {
 export default function ImportsIndexRoute({
 	loaderData,
 }: Route.ComponentProps) {
-	const { imports } = loaderData
+	const { imports, strava } = loaderData
 
 	return (
 		<main className="container py-10">
@@ -66,6 +78,28 @@ export default function ImportsIndexRoute({
 					Upload activity
 				</Link>
 			</div>
+
+			{strava.configured ? (
+				<Card className="mb-6">
+					<CardHeader className="flex flex-row items-center justify-between gap-3">
+						<div className="space-y-0.5">
+							<CardTitle className="text-base">Strava</CardTitle>
+							<CardDescription>
+								{strava.connected
+									? 'Connected to Strava'
+									: 'Connect your Strava account to import activities automatically.'}
+							</CardDescription>
+						</div>
+						{strava.connected ? (
+							<Badge variant="default">Connected</Badge>
+						) : (
+							<Form method="post" action="/integrations/strava/connect">
+								<Button type="submit">Connect Strava</Button>
+							</Form>
+						)}
+					</CardHeader>
+				</Card>
+			) : null}
 
 			{imports.length === 0 ? (
 				<Card>

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -91,7 +91,14 @@ export default function ImportsIndexRoute({
 							</CardDescription>
 						</div>
 						{strava.connected ? (
-							<Badge variant="default">Connected</Badge>
+							<div className="flex items-center gap-2">
+								<Badge variant="default">Connected</Badge>
+								<Form method="post" action="/integrations/strava/sync">
+									<Button type="submit" variant="outline" size="sm">
+										Sync now
+									</Button>
+								</Form>
+							</div>
 						) : (
 							<Form method="post" action="/integrations/strava/connect">
 								<Button type="submit">Connect Strava</Button>

--- a/app/routes/integrations.strava.callback.test.ts
+++ b/app/routes/integrations.strava.callback.test.ts
@@ -1,0 +1,149 @@
+import { invariant } from '@epic-web/invariant'
+import { faker } from '@faker-js/faker'
+import { http, HttpResponse } from 'msw'
+import { type AppLoadContext } from 'react-router'
+import { expect, test } from 'vitest'
+import { STRAVA_OAUTH_STATE_COOKIE } from '#app/integrations/strava/oauth.server.ts'
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { server } from '#tests/mocks/index.ts'
+import { consoleError } from '#tests/setup/setup-test-env.ts'
+import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
+import { loader } from './integrations.strava.callback.tsx'
+
+const ROUTE_PATH = '/integrations/strava/callback'
+const LOADER_ARGS_BASE = {
+	params: {},
+	context: {} as AppLoadContext,
+	unstable_pattern: ROUTE_PATH,
+}
+
+async function setupUser() {
+	const session = await prisma.session.create({
+		data: {
+			expirationDate: getSessionExpirationDate(),
+			user: { create: { ...createUser() } },
+		},
+		select: { id: true, userId: true },
+	})
+	return session
+}
+
+async function setupRequest({
+	session,
+	code = faker.string.uuid(),
+	state = faker.string.uuid(),
+	cookieState = state,
+	error,
+}: {
+	session: { id: string }
+	code?: string | null
+	state?: string | null
+	cookieState?: string | null
+	error?: string
+}) {
+	const url = new URL(ROUTE_PATH, BASE_URL)
+	if (code != null) url.searchParams.set('code', code)
+	if (state != null) url.searchParams.set('state', state)
+	if (error) url.searchParams.set('error', error)
+
+	const sessionCookie = await getSessionCookieHeader(session)
+	const cookies = [sessionCookie]
+	if (cookieState != null) {
+		cookies.push(`${STRAVA_OAUTH_STATE_COOKIE}=${cookieState}`)
+	}
+	return new Request(url.toString(), {
+		method: 'GET',
+		headers: { cookie: cookies.join('; ') },
+	})
+}
+
+test('happy path: persists an active Strava Account Connection', async () => {
+	const session = await setupUser()
+	const request = await setupRequest({ session })
+
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({ title: 'Connected to Strava', type: 'success' }),
+	)
+
+	const connection = await prisma.accountConnection.findUnique({
+		where: {
+			athleteId_provider: { athleteId: session.userId, provider: 'strava' },
+		},
+	})
+	invariant(connection, 'expected an Account Connection to be created')
+	expect(connection.status).toBe('active')
+	expect(connection.externalAthleteId).toBe('12345678')
+	expect(connection.accessToken).toBeTruthy()
+	expect(connection.refreshToken).toBeTruthy()
+	expect(connection.connectedAt).toBeInstanceOf(Date)
+})
+
+test('rejects a state mismatch (CSRF) without creating a connection', async () => {
+	const session = await setupUser()
+	const request = await setupRequest({
+		session,
+		state: 'returned-state',
+		cookieState: 'different-cookie-state',
+	})
+
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({
+			title: 'Strava connection failed',
+			type: 'error',
+		}),
+	)
+	const connection = await prisma.accountConnection.findUnique({
+		where: {
+			athleteId_provider: { athleteId: session.userId, provider: 'strava' },
+		},
+	})
+	expect(connection).toBeNull()
+})
+
+test('handles a non-200 from the Strava token exchange', async () => {
+	server.use(
+		http.post('https://www.strava.com/oauth/token', () =>
+			HttpResponse.json({ message: 'Bad Request' }, { status: 400 }),
+		),
+	)
+	const session = await setupUser()
+	const request = await setupRequest({ session })
+
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({
+			title: 'Strava connection failed',
+			type: 'error',
+		}),
+	)
+	const connection = await prisma.accountConnection.findUnique({
+		where: {
+			athleteId_provider: { athleteId: session.userId, provider: 'strava' },
+		},
+	})
+	expect(connection).toBeNull()
+	// no console.error expected — the failure is handled gracefully
+	expect(consoleError).not.toHaveBeenCalled()
+})
+
+test('denied consent at Strava redirects with an error toast', async () => {
+	const session = await setupUser()
+	const request = await setupRequest({ session, error: 'access_denied' })
+
+	const response = await loader({ request, ...LOADER_ARGS_BASE })
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({ type: 'error' }),
+	)
+})

--- a/app/routes/integrations.strava.callback.tsx
+++ b/app/routes/integrations.strava.callback.tsx
@@ -1,0 +1,98 @@
+import { stravaApiGet } from '#app/integrations/strava/client.server.ts'
+import {
+	destroyStravaOAuthStateCookie,
+	exchangeStravaCode,
+	getStravaOAuthState,
+	stravaExpiresAtToDate,
+	verifyStravaOAuthState,
+} from '#app/integrations/strava/oauth.server.ts'
+import {
+	STRAVA_PROVIDER,
+	StravaAthleteSchema,
+} from '#app/integrations/strava/types.ts'
+import { connectAccountConnection } from '#app/utils/account-connection.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { type Route } from './+types/integrations.strava.callback.ts'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const url = new URL(request.url)
+
+	const error = url.searchParams.get('error')
+	const code = url.searchParams.get('code')
+	const queryState = url.searchParams.get('state')
+	const cookieState = getStravaOAuthState(request)
+
+	// Always clear the one-shot state cookie on the way out.
+	const clearStateHeaders = { 'set-cookie': destroyStravaOAuthStateCookie }
+	const failure = (description: string) =>
+		redirectWithToast(
+			'/imports',
+			{ title: 'Strava connection failed', description, type: 'error' },
+			{ headers: clearStateHeaders },
+		)
+
+	// Athlete declined consent at Strava.
+	if (error) {
+		return failure('Authorization was denied.')
+	}
+
+	// CSRF guard: the returned state must match the cookie we set at start.
+	if (!verifyStravaOAuthState(cookieState, queryState)) {
+		return failure('Security check failed. Please try connecting again.')
+	}
+
+	if (!code) {
+		return failure('Strava did not return an authorization code.')
+	}
+
+	let tokens
+	try {
+		tokens = await exchangeStravaCode(code)
+	} catch {
+		return failure('Could not exchange the authorization code with Strava.')
+	}
+
+	// Strava usually returns the athlete summary inline; otherwise fetch it.
+	let externalAthleteId: string
+	if (tokens.athlete) {
+		externalAthleteId = tokens.athlete.id
+	} else {
+		try {
+			const athlete = StravaAthleteSchema.parse(
+				await stravaApiGet(
+					{
+						id: 'pending',
+						accessToken: tokens.access_token,
+						refreshToken: tokens.refresh_token,
+						expiresAt: stravaExpiresAtToDate(tokens.expires_at),
+					},
+					'/athlete',
+				),
+			)
+			externalAthleteId = athlete.id
+		} catch {
+			return failure('Could not read your Strava athlete profile.')
+		}
+	}
+
+	await connectAccountConnection({
+		athleteId: userId,
+		provider: STRAVA_PROVIDER,
+		externalAthleteId,
+		accessToken: tokens.access_token,
+		refreshToken: tokens.refresh_token,
+		expiresAt: stravaExpiresAtToDate(tokens.expires_at),
+	})
+
+	return redirectWithToast(
+		'/imports',
+		{
+			title: 'Connected to Strava',
+			description: 'Your Strava account is now linked to Trainm8.',
+			type: 'success',
+		},
+		{ headers: clearStateHeaders },
+	)
+}

--- a/app/routes/integrations.strava.connect.test.ts
+++ b/app/routes/integrations.strava.connect.test.ts
@@ -1,0 +1,57 @@
+import { invariant } from '@epic-web/invariant'
+import { type AppLoadContext } from 'react-router'
+import { expect, test } from 'vitest'
+import {
+	STRAVA_OAUTH_STATE_COOKIE,
+} from '#app/integrations/strava/oauth.server.ts'
+import { STRAVA_SCOPE } from '#app/integrations/strava/types.ts'
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
+import { action } from './integrations.strava.connect.tsx'
+
+const ROUTE_PATH = '/integrations/strava/connect'
+const ACTION_ARGS_BASE = {
+	params: {},
+	context: {} as AppLoadContext,
+	unstable_pattern: ROUTE_PATH,
+}
+
+async function setupUser() {
+	const session = await prisma.session.create({
+		data: {
+			expirationDate: getSessionExpirationDate(),
+			user: { create: { ...createUser() } },
+		},
+		select: { id: true, userId: true },
+	})
+	return session
+}
+
+test('redirects to Strava authorize with scope and a CSRF state cookie', async () => {
+	const session = await setupUser()
+	const request = new Request(new URL(ROUTE_PATH, BASE_URL).toString(), {
+		method: 'POST',
+		headers: { cookie: await getSessionCookieHeader(session) },
+	})
+
+	const response = await action({ request, ...ACTION_ARGS_BASE })
+	invariant(response instanceof Response, 'expected a redirect Response')
+
+	const location = response.headers.get('location')
+	invariant(location, 'expected a Location header')
+	const redirectUrl = new URL(location)
+	expect(redirectUrl.origin + redirectUrl.pathname).toBe(
+		'https://www.strava.com/oauth/authorize',
+	)
+	expect(redirectUrl.searchParams.get('scope')).toBe(STRAVA_SCOPE)
+	expect(redirectUrl.searchParams.get('response_type')).toBe('code')
+	const state = redirectUrl.searchParams.get('state')
+	invariant(state, 'expected a state param')
+
+	const setCookie = response.headers.get('set-cookie')
+	invariant(setCookie, 'expected a Set-Cookie header')
+	expect(setCookie).toContain(`${STRAVA_OAUTH_STATE_COOKIE}=${state}`)
+	expect(setCookie.toLowerCase()).toContain('httponly')
+})

--- a/app/routes/integrations.strava.connect.tsx
+++ b/app/routes/integrations.strava.connect.tsx
@@ -1,0 +1,30 @@
+import { redirect } from 'react-router'
+import {
+	buildStravaAuthorization,
+	isStravaOAuthConfigured,
+} from '#app/integrations/strava/oauth.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { type Route } from './+types/integrations.strava.connect.ts'
+
+/** Starting the OAuth flow is a state-changing POST (CSRF-safe). */
+export async function action({ request }: Route.ActionArgs) {
+	await requireUserId(request)
+
+	if (!isStravaOAuthConfigured()) {
+		return redirectWithToast('/imports', {
+			title: 'Strava unavailable',
+			description: 'Strava is not configured on this server.',
+			type: 'error',
+		})
+	}
+
+	const { url, setCookie } = buildStravaAuthorization()
+	return redirect(url, { headers: { 'set-cookie': setCookie } })
+}
+
+/** A bare GET to the start route just bounces back to the inbox. */
+export async function loader({ request }: Route.LoaderArgs) {
+	await requireUserId(request)
+	return redirect('/imports')
+}

--- a/app/routes/integrations.strava.sync.test.ts
+++ b/app/routes/integrations.strava.sync.test.ts
@@ -1,0 +1,75 @@
+import { type AppLoadContext } from 'react-router'
+import { expect, test } from 'vitest'
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
+import { action } from './integrations.strava.sync.tsx'
+
+const ROUTE_PATH = '/integrations/strava/sync'
+const ACTION_ARGS_BASE = {
+	params: {},
+	context: {} as AppLoadContext,
+	unstable_pattern: ROUTE_PATH,
+}
+
+async function setupUser() {
+	const session = await prisma.session.create({
+		data: {
+			expirationDate: getSessionExpirationDate(),
+			user: { create: { ...createUser() } },
+		},
+		select: { id: true, userId: true },
+	})
+	return session
+}
+
+async function request(session: { id: string }) {
+	return new Request(new URL(ROUTE_PATH, BASE_URL).toString(), {
+		method: 'POST',
+		headers: { cookie: await getSessionCookieHeader(session) },
+	})
+}
+
+test('syncs a connected athlete and reports success', async () => {
+	const session = await setupUser()
+	await prisma.accountConnection.create({
+		data: {
+			athleteId: session.userId,
+			provider: 'strava',
+			externalAthleteId: '12345678',
+			accessToken: 'tok',
+			refreshToken: 'ref',
+			expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+			connectedAt: new Date('2026-05-01T00:00:00.000Z'),
+		},
+	})
+
+	const response = await action({
+		request: await request(session),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({ title: 'Synced with Strava', type: 'success' }),
+	)
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: session.userId },
+	})
+	expect(imports.length).toBeGreaterThan(0)
+})
+
+test('reports an error when the athlete is not connected', async () => {
+	const session = await setupUser()
+
+	const response = await action({
+		request: await request(session),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response).toHaveRedirect('/imports')
+	await expect(response).toSendToast(
+		expect.objectContaining({ title: 'Sync failed', type: 'error' }),
+	)
+})

--- a/app/routes/integrations.strava.sync.tsx
+++ b/app/routes/integrations.strava.sync.tsx
@@ -1,0 +1,41 @@
+import { redirect } from 'react-router'
+import { syncStravaActivities } from '#app/integrations/strava/sync.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { type Route } from './+types/integrations.strava.sync.ts'
+
+/** Manual "Sync now" is a state-changing POST from the Imports surface. */
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	const result = await syncStravaActivities(userId)
+
+	if (!result.ok) {
+		const description =
+			result.reason === 'revoked'
+				? 'Your Strava authorization was revoked. Please reconnect.'
+				: 'Connect your Strava account before syncing.'
+		return redirectWithToast('/imports', {
+			title: 'Sync failed',
+			description,
+			type: 'error',
+		})
+	}
+
+	const description =
+		result.created === 0
+			? 'No new activities to import.'
+			: `Imported ${result.created} new ${
+					result.created === 1 ? 'activity' : 'activities'
+				}.`
+	return redirectWithToast('/imports', {
+		title: 'Synced with Strava',
+		description,
+		type: 'success',
+	})
+}
+
+/** A bare GET just bounces back to the inbox. */
+export async function loader({ request }: Route.LoaderArgs) {
+	await requireUserId(request)
+	return redirect('/imports')
+}

--- a/app/utils/account-connection.server.ts
+++ b/app/utils/account-connection.server.ts
@@ -1,0 +1,75 @@
+import { prisma } from './db.server.ts'
+
+/**
+ * The canonical Account Connection status state machine (CONTEXT.md, ADR 0014).
+ * The `AccountConnection.status` column is constrained to these values both at
+ * the database level (CHECK constraint) and here.
+ *
+ *  - `active`  — authorized and syncable.
+ *  - `expired` — access token lapsed; self-heals via background refresh and is
+ *                not surfaced to the athlete.
+ *  - `revoked` — source provider invalidated the authorization; needs the
+ *                athlete to re-authorize.
+ *  - `error`   — unexpected source-side failure requiring triage.
+ *
+ * Operational sync state (idle / actively fetching) is NOT a status value — it
+ * is derived from the job queue.
+ */
+export const ACCOUNT_CONNECTION_STATUSES = [
+	'active',
+	'expired',
+	'revoked',
+	'error',
+] as const
+
+export type AccountConnectionStatus =
+	(typeof ACCOUNT_CONNECTION_STATUSES)[number]
+
+export function isAccountConnectionStatus(
+	value: string,
+): value is AccountConnectionStatus {
+	return (ACCOUNT_CONNECTION_STATUSES as readonly string[]).includes(value)
+}
+
+/** The active Account Connection for an athlete/provider, if any. */
+export function getAccountConnection(athleteId: string, provider: string) {
+	return prisma.accountConnection.findUnique({
+		where: { athleteId_provider: { athleteId, provider } },
+	})
+}
+
+/**
+ * Persist a freshly-authorized Account Connection as `active`, stamping
+ * `connectedAt = now()`. Re-connecting an existing provider rotates the stored
+ * tokens and re-activates the row (idempotent on the athlete/provider pair).
+ */
+export function connectAccountConnection({
+	athleteId,
+	provider,
+	externalAthleteId,
+	accessToken,
+	refreshToken,
+	expiresAt,
+}: {
+	athleteId: string
+	provider: string
+	externalAthleteId: string
+	accessToken: string
+	refreshToken: string
+	expiresAt: Date
+}) {
+	const now = new Date()
+	const tokens = {
+		externalAthleteId,
+		accessToken,
+		refreshToken,
+		expiresAt,
+		status: 'active' satisfies AccountConnectionStatus,
+		connectedAt: now,
+	}
+	return prisma.accountConnection.upsert({
+		where: { athleteId_provider: { athleteId, provider } },
+		create: { athleteId, provider, ...tokens },
+		update: tokens,
+	})
+}

--- a/app/utils/activity-import.server.ts
+++ b/app/utils/activity-import.server.ts
@@ -104,6 +104,10 @@ export async function autoMatchImport(
 	})
 	if (!imported) return null
 
+	// 'other' is an import-only discipline (ADR 0015): it has no modeled planned
+	// session to match against, so it stays in the inbox for manual handling.
+	if (imported.discipline === 'other') return null
+
 	const { start: dayStart, end: dayEnd } = localDayBoundsUTC(
 		imported.startedAt,
 		athleteTimezone,

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -18,6 +18,13 @@ const schema = z.object({
 	GITHUB_REDIRECT_URI: z.string().optional(),
 	GITHUB_TOKEN: z.string().optional(),
 
+	// Strava Account Connection (ADR 0014). Optional: when unset, the connect
+	// affordance is hidden and the OAuth routes report the integration as
+	// unconfigured rather than crashing.
+	STRAVA_CLIENT_ID: z.string().optional(),
+	STRAVA_CLIENT_SECRET: z.string().optional(),
+	STRAVA_REDIRECT_URI: z.string().optional(),
+
 	ALLOW_INDEXING: z.enum(['true', 'false']).optional(),
 
 	// Tigris Object Storage Configuration

--- a/app/utils/load/compute.test.ts
+++ b/app/utils/load/compute.test.ts
@@ -212,6 +212,15 @@ test('strength: returns null when no RPE', () => {
 	expect(result).toBeNull()
 })
 
+test('other: never contributes TSS, even with RPE (ADR 0015)', () => {
+	const result = computeSessionTss(
+		{ discipline: 'other', durationSec: 3600, rpe: 7 },
+		{ hrAvg: 150, powerAvg: null, paceAvgSecPerKm: null },
+		baseProfile,
+	)
+	expect(result).toBeNull()
+})
+
 // ── EWMA recurrence math ──────────────────────────────────────────────────
 
 test('ewmaStep: 42-day CTL starts at 0, after 1 day of 100 TSS ≈ 2.38', () => {

--- a/app/utils/load/compute.ts
+++ b/app/utils/load/compute.ts
@@ -45,6 +45,10 @@ export function computeSessionTss(
 	const { discipline, durationSec, rpe } = session
 	const { hrAvg, powerAvg, paceAvgSecPerKm } = recording
 
+	// 'other' is an import-only discipline (ADR 0015): activities trainm8 does not
+	// model never contribute to TSS or Training Load — their metric is Unavailable.
+	if (discipline === 'other') return null
+
 	const dp = athleteProfile.disciplineProfiles.find(
 		(p) => p.discipline === discipline,
 	)

--- a/prisma/migrations/20260528184726_add_account_connection/migration.sql
+++ b/prisma/migrations/20260528184726_add_account_connection/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "AccountConnection" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "provider" TEXT NOT NULL,
+    "externalAthleteId" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "refreshToken" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active' CHECK ("status" IN ('active', 'expired', 'revoked', 'error')),
+    "connectedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSyncedAt" DATETIME,
+    "backfillCompletedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "athleteId" TEXT NOT NULL,
+    CONSTRAINT "AccountConnection_athleteId_fkey" FOREIGN KEY ("athleteId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "AccountConnection_athleteId_idx" ON "AccountConnection"("athleteId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccountConnection_athleteId_provider_key" ON "AccountConnection"("athleteId", "provider");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,19 +20,20 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  image          UserImage?
-  password       Password?
-  roles          Role[]
-  sessions       Session[]
-  connections    Connection[]
-  passkey        Passkey[]
-  workouts         Workout[]
-  trainingSessions WorkoutSession[]
-  athleteProfile   AthleteProfile?
-  exercises        Exercise[]
-  activityImports  ActivityImport[]
-  events           Event[]
-  loadSnapshots    LoadSnapshot[]
+  image              UserImage?
+  password           Password?
+  roles              Role[]
+  sessions           Session[]
+  connections        Connection[]
+  passkey            Passkey[]
+  workouts           Workout[]
+  trainingSessions   WorkoutSession[]
+  athleteProfile     AthleteProfile?
+  exercises          Exercise[]
+  activityImports    ActivityImport[]
+  events             Event[]
+  loadSnapshots      LoadSnapshot[]
+  accountConnections AccountConnection[]
 }
 
 model UserImage {
@@ -158,16 +159,16 @@ model Passkey {
 }
 
 model Workout {
-  id           String   @id @default(cuid())
-  title        String
-  description  String?
-  discipline   String   // "run" | "swim" | "bike" | "strength"
-  intent       String   // see WORKOUT_INTENTS in workout-schema.ts
+  id          String  @id @default(cuid())
+  title       String
+  description String?
+  discipline  String // "run" | "swim" | "bike" | "strength"
+  intent      String // see WORKOUT_INTENTS in workout-schema.ts
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  owner    User     @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  owner    User             @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   ownerId  String
   blocks   WorkoutBlock[]
   sessions WorkoutSession[]
@@ -189,28 +190,28 @@ model WorkoutBlock {
 }
 
 model WorkoutStep {
-  id                 String  @id @default(cuid())
-  kind               String  @default("cardio") // "cardio" | "strength" | "rest"
-  notes              String? // free-text notes (was description)
-  orderIndex         Int
+  id         String  @id @default(cuid())
+  kind       String  @default("cardio") // "cardio" | "strength" | "rest"
+  notes      String? // free-text notes (was description)
+  orderIndex Int
 
   // cardio-only fields
-  discipline         String? // "run" | "swim" | "bike"
-  intensity          String? // JSON: IntensityTarget discriminated union (see workout-schema.ts)
-  durationSec        Int?
-  distanceM          Int?
+  discipline  String? // "run" | "swim" | "bike"
+  intensity   String? // JSON: IntensityTarget discriminated union (see workout-schema.ts)
+  durationSec Int?
+  distanceM   Int?
 
   // strength-only fields
   exerciseId         String?
   restBetweenSetsSec Int?
 
   // resolved intensity ranges (filled by background job)
-  intensityHrMin     Int?
-  intensityHrMax     Int?
-  intensityPowerMin  Int?
-  intensityPowerMax  Int?
-  intensityPaceMin   Int?
-  intensityPaceMax   Int?
+  intensityHrMin    Int?
+  intensityHrMax    Int?
+  intensityPowerMin Int?
+  intensityPowerMax Int?
+  intensityPaceMin  Int?
+  intensityPaceMax  Int?
 
   block    WorkoutBlock  @relation(fields: [blockId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   blockId  String
@@ -222,27 +223,27 @@ model WorkoutStep {
 }
 
 model Exercise {
-  id                  String  @id @default(cuid())
-  name                String
-  primaryMuscle       String  // MuscleGroup: chest | back | shoulders | biceps | triceps | forearms | abs | obliques | lower-back | glutes | quads | hamstrings | calves | hip-flexors | full-body
-  equipment           String? // e.g. "barbell" | "dumbbell" | "bodyweight" | "machine" | "cable"
-  isCompound          Boolean @default(false)
-  createdByAthleteId  String? // null for seed/catalog entries
+  id                 String  @id @default(cuid())
+  name               String
+  primaryMuscle      String // MuscleGroup: chest | back | shoulders | biceps | triceps | forearms | abs | obliques | lower-back | glutes | quads | hamstrings | calves | hip-flexors | full-body
+  equipment          String? // e.g. "barbell" | "dumbbell" | "bodyweight" | "machine" | "cable"
+  isCompound         Boolean @default(false)
+  createdByAthleteId String? // null for seed/catalog entries
 
-  createdBy User?        @relation(fields: [createdByAthleteId], references: [id], onDelete: SetNull)
+  createdBy User?         @relation(fields: [createdByAthleteId], references: [id], onDelete: SetNull)
   steps     WorkoutStep[]
 
   @@index([createdByAthleteId])
 }
 
 model ExerciseSet {
-  id          String @id @default(cuid())
-  orderIndex  Int
-  kind        String // "reps" | "timed" | "amrap"
+  id         String @id @default(cuid())
+  orderIndex Int
+  kind       String // "reps" | "timed" | "amrap"
 
   // load — mutually exclusive
-  weightKg    Float?
-  pct1RM      Float?
+  weightKg Float?
+  pct1RM   Float?
 
   // kind-specific quantities
   reps        Int?
@@ -255,23 +256,23 @@ model ExerciseSet {
 }
 
 model WorkoutSession {
-  id             String   @id @default(cuid())
-  scheduledAt    DateTime // stored UTC
-  status         String   @default("scheduled") // "scheduled" | "completed" | "skipped" | "missed"
-  tssValue       Float?   // computed TSS for this session (null = unavailable)
-  tssFormula     String?  // 'coggan' | 'hrTSS' | 'rTSS' | 'sTSS' | 'sRPE'
-  tssConfidence  String?  // 'high' | 'medium' | 'low'
+  id            String   @id @default(cuid())
+  scheduledAt   DateTime // stored UTC
+  status        String   @default("scheduled") // "scheduled" | "completed" | "skipped" | "missed"
+  tssValue      Float? // computed TSS for this session (null = unavailable)
+  tssFormula    String? // 'coggan' | 'hrTSS' | 'rTSS' | 'sTSS' | 'sRPE'
+  tssConfidence String? // 'high' | 'medium' | 'low'
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user        User            @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  userId      String
-  workout     Workout?        @relation(fields: [workoutId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  workoutId   String?         // nullable — recording-only sessions have no Workout
-  recording   ActivityImport? @relation("SessionRecording", fields: [recordingId], references: [id])
-  recordingId String?         // nullable FK to ActivityImport
-  sessionLog  SessionLog?
+  user         User            @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId       String
+  workout      Workout?        @relation(fields: [workoutId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  workoutId    String? // nullable — recording-only sessions have no Workout
+  recording    ActivityImport? @relation("SessionRecording", fields: [recordingId], references: [id])
+  recordingId  String? // nullable FK to ActivityImport
+  sessionLog   SessionLog?
   eventResults Event[]
 
   promotedImports ActivityImport[] @relation("ImportPromotedTo")
@@ -343,12 +344,12 @@ model ThresholdEvent {
 model Event {
   id          String    @id @default(cuid())
   name        String
-  kind        String    // 'race' | 'time-trial' | 'fitness-goal'
-  priority    String    // 'A' | 'B' | 'C'
+  kind        String // 'race' | 'time-trial' | 'fitness-goal'
+  priority    String // 'A' | 'B' | 'C'
   startDate   DateTime
   endDate     DateTime?
-  disciplines String    // JSON-encoded Discipline[]
-  target      String?   // JSON-encoded EventTarget
+  disciplines String // JSON-encoded Discipline[]
+  target      String? // JSON-encoded EventTarget
   location    String?
   status      String    @default("planned") // 'planned' | 'completed' | 'cancelled'
   notes       String?
@@ -368,38 +369,38 @@ model Event {
 model SessionLog {
   id      String @id @default(cuid())
   content String // athlete's text reflection
-  rpe     Int?   // Rate of Perceived Exertion, 1–10
+  rpe     Int? // Rate of Perceived Exertion, 1–10
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   session   WorkoutSession @relation(fields: [sessionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sessionId String           @unique
+  sessionId String         @unique
 }
 
 model ActivityImport {
   id                String   @id @default(cuid())
   athleteId         String
-  externalProvider  String   // 'manual' | 'strava' | 'garmin'
+  externalProvider  String // 'manual' | 'strava' | 'garmin'
   externalId        String
   startedAt         DateTime
   endedAt           DateTime
   durationSec       Int
   distanceM         Float?
-  discipline        String   // run | bike | swim | strength
+  discipline        String // run | bike | swim | strength
   hrAvg             Float?
   powerAvg          Float?
   paceAvgSecPerKm   Float?
   polyline          String?
-  rawJson           String   // JSON-encoded; stash extra fields including fileBlob
+  rawJson           String // JSON-encoded; stash extra fields including fileBlob
   promotedSessionId String?
-  tssValue          Float?   // computed TSS (null = unavailable)
-  tssFormula        String?  // 'coggan' | 'hrTSS' | 'rTSS' | 'sTSS' | 'sRPE'
-  tssConfidence     String?  // 'high' | 'medium' | 'low'
+  tssValue          Float? // computed TSS (null = unavailable)
+  tssFormula        String? // 'coggan' | 'hrTSS' | 'rTSS' | 'sTSS' | 'sRPE'
+  tssConfidence     String? // 'high' | 'medium' | 'low'
   createdAt         DateTime @default(now())
 
-  athlete         User            @relation(fields: [athleteId], references: [id], onDelete: Cascade)
-  promotedSession WorkoutSession? @relation("ImportPromotedTo", fields: [promotedSessionId], references: [id])
+  athlete         User             @relation(fields: [athleteId], references: [id], onDelete: Cascade)
+  promotedSession WorkoutSession?  @relation("ImportPromotedTo", fields: [promotedSessionId], references: [id])
   recordingFor    WorkoutSession[] @relation("SessionRecording")
 
   @@unique([externalProvider, externalId])
@@ -407,19 +408,45 @@ model ActivityImport {
 }
 
 model LoadSnapshot {
-  id               String   @id @default(cuid())
-  athleteId        String
-  date             String   // YYYY-MM-DD in athlete timezone
-  tssTotal         Float    @default(0)
-  tssByDiscipline  String   @default("{}") // JSON: { bike?, run?, swim?, strength? }
-  ctl              Float    @default(0) // chronic training load (42-day EWMA)
-  atl              Float    @default(0) // acute training load (7-day EWMA)
-  tsb              Float    @default(0) // training stress balance = CTL - ATL (prior day)
-  computedAt       DateTime @default(now())
+  id              String   @id @default(cuid())
+  athleteId       String
+  date            String // YYYY-MM-DD in athlete timezone
+  tssTotal        Float    @default(0)
+  tssByDiscipline String   @default("{}") // JSON: { bike?, run?, swim?, strength? }
+  ctl             Float    @default(0) // chronic training load (42-day EWMA)
+  atl             Float    @default(0) // acute training load (7-day EWMA)
+  tsb             Float    @default(0) // training stress balance = CTL - ATL (prior day)
+  computedAt      DateTime @default(now())
 
   athlete User @relation(fields: [athleteId], references: [id], onDelete: Cascade)
 
   @@unique([athleteId, date])
   @@index([athleteId])
   @@index([athleteId, date])
+}
+
+/// An athlete's authorized link to an external training service account
+/// (Strava, Garmin, Polar). One per athlete per external service. See CONTEXT.md
+/// "Account Connection" and ADR 0014. The `provider` column is a plain string,
+/// not an enum the schema discriminates on.
+model AccountConnection {
+  id                  String    @id @default(cuid())
+  provider            String // 'strava' | 'garmin' | 'polar'
+  externalAthleteId   String // the external service's athlete id
+  accessToken         String
+  refreshToken        String
+  expiresAt           DateTime // when the access token expires
+  status              String    @default("active") // 'active' | 'expired' | 'revoked' | 'error'
+  connectedAt         DateTime  @default(now())
+  lastSyncedAt        DateTime? // high-water mark for manual sync / reconciliation
+  backfillCompletedAt DateTime? // set once the Backfill Window job completes
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  athlete   User   @relation(fields: [athleteId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  athleteId String
+
+  @@unique([athleteId, provider])
+  @@index([athleteId])
 }

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -3,6 +3,7 @@ import { setupServer } from 'msw/node'
 import { handlers as githubHandlers } from './github.ts'
 import { handlers as pwnedPasswordApiHandlers } from './pwned-passwords.ts'
 import { handlers as resendHandlers } from './resend.ts'
+import { handlers as stravaHandlers } from './strava.ts'
 import { handlers as tigrisHandlers } from './tigris.ts'
 
 export const server = setupServer(
@@ -10,6 +11,7 @@ export const server = setupServer(
 	...githubHandlers,
 	...tigrisHandlers,
 	...pwnedPasswordApiHandlers,
+	...stravaHandlers,
 )
 
 server.listen({

--- a/tests/mocks/strava.ts
+++ b/tests/mocks/strava.ts
@@ -1,0 +1,28 @@
+import { http, HttpResponse, type HttpHandler } from 'msw'
+
+const { json } = HttpResponse
+
+/**
+ * Default happy-path Strava mocks. Tests override these with `server.use(...)`
+ * to exercise error branches (e.g. a non-200 token exchange).
+ */
+export const handlers: Array<HttpHandler> = [
+	http.post('https://www.strava.com/oauth/token', async ({ request }) => {
+		const body = (await request.json().catch(() => ({}))) as Record<
+			string,
+			unknown
+		>
+		const nowSec = Math.floor(Date.now() / 1000)
+		return json({
+			token_type: 'Bearer',
+			access_token: `mock_access_${body.code ?? body.refresh_token ?? 'token'}`,
+			refresh_token: 'mock_refresh_token',
+			expires_at: nowSec + 6 * 60 * 60,
+			athlete: { id: 12345678, username: 'mock_athlete' },
+		})
+	}),
+
+	http.get('https://www.strava.com/api/v3/athlete', () =>
+		json({ id: 12345678, username: 'mock_athlete' }),
+	),
+]

--- a/tests/mocks/strava.ts
+++ b/tests/mocks/strava.ts
@@ -25,4 +25,55 @@ export const handlers: Array<HttpHandler> = [
 	http.get('https://www.strava.com/api/v3/athlete', () =>
 		json({ id: 12345678, username: 'mock_athlete' }),
 	),
+
+	// Default activity feed spanning multiple disciplines, including one
+	// unmodeled type ('Hike' → 'other'). Tests override this to exercise
+	// pagination, 401-refresh, and revoked branches.
+	http.get('https://www.strava.com/api/v3/athlete/activities', () =>
+		json([
+			{
+				id: 1001,
+				name: 'Morning Run',
+				sport_type: 'Run',
+				type: 'Run',
+				distance: 10000,
+				moving_time: 3000,
+				elapsed_time: 3100,
+				start_date: '2026-05-20T06:00:00Z',
+				average_heartrate: 150,
+				map: { summary_polyline: 'abc' },
+			},
+			{
+				id: 1002,
+				name: 'Lunch Ride',
+				sport_type: 'Ride',
+				type: 'Ride',
+				distance: 40000,
+				moving_time: 4800,
+				elapsed_time: 5000,
+				start_date: '2026-05-21T11:00:00Z',
+				average_watts: 210,
+			},
+			{
+				id: 1003,
+				name: 'Pool Swim',
+				sport_type: 'Swim',
+				type: 'Swim',
+				distance: 2000,
+				moving_time: 2400,
+				elapsed_time: 2500,
+				start_date: '2026-05-22T07:00:00Z',
+			},
+			{
+				id: 1004,
+				name: 'Evening Hike',
+				sport_type: 'Hike',
+				type: 'Hike',
+				distance: 6000,
+				moving_time: 5400,
+				elapsed_time: 6000,
+				start_date: '2026-05-23T17:00:00Z',
+			},
+		]),
+	),
 ]


### PR DESCRIPTION
## Summary

Implements Strava OAuth 2.0 integration to allow athletes to authorize and connect their Strava accounts. This adds the foundational infrastructure for syncing Strava activities into trainm8.

### Key Changes

**Database & Schema**
- Added `AccountConnection` model to store OAuth tokens and connection metadata for external providers
- Added `accountConnections` relation to `User` model
- Includes status state machine (`active`, `expired`, `revoked`, `error`) and token expiry tracking
- Migration includes CHECK constraint on status values

**Strava Integration Module** (`app/integrations/strava/`)
- `types.ts`: Strava API schemas (token response, athlete summary) and constants
- `oauth.server.ts`: OAuth flow primitives (authorization URL building, state verification, token exchange)
- `client.server.ts`: Authenticated API client with automatic token refresh and rotation
- `discipline-map.ts`: Maps Strava activity types to trainm8 disciplines (run/bike/swim/strength/other)

**OAuth Routes**
- `integrations.strava.connect.tsx`: POST action that initiates the OAuth flow with CSRF state cookie
- `integrations.strava.callback.tsx`: Callback handler that exchanges code for tokens, verifies CSRF state, and persists the connection

**UI Updates**
- Updated `/imports` page to display Strava connection status and provide connect/disconnect affordances
- Conditional rendering based on OAuth configuration and connection state

**Utilities**
- `account-connection.server.ts`: Connection lifecycle helpers (upsert, fetch, status validation)
- Environment variables for Strava credentials (CLIENT_ID, CLIENT_SECRET, REDIRECT_URI)

**Testing**
- Comprehensive test coverage for OAuth flow (happy path, CSRF protection, error handling)
- MSW mocks for Strava token and athlete endpoints
- Discipline mapping unit tests

### Design Notes

- Strava integration is private to `app/integrations/strava/` (ADR 0014) — other parts of the app interact via `AccountConnection` model
- Token refresh is automatic with 60s safety margin before expiry
- Refresh tokens rotate on each refresh and are persisted immediately
- CSRF protection via httpOnly state cookie with 10-minute TTL
- Connection status is idempotent on athlete/provider pair (upsert semantics)

## Test Plan

- Run `npm test` to verify all new tests pass (OAuth flow, token exchange, CSRF validation, discipline mapping)
- Manual verification: Connect a Strava account via the imports page, confirm connection persists and displays as active
- Verify error handling: test CSRF mismatch, token exchange failure, and user consent denial

## Checklist

- [x] Tests updated (added comprehensive OAuth and integration tests)
- [x] Docs updated (schema comments, ADR references in code)

https://claude.ai/code/session_01EuqsgKStTDShNLD2LnPQ6E