### PR TITLE
Add Strava OAuth integration with Account Connection management

### DIFF
--- a/app/components/ui/alert-dialog.tsx
+++ b/app/components/ui/alert-dialog.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog'
+import { type ComponentProps } from 'react'
+
+import { cn } from '#app/utils/misc.tsx'
+import { buttonVariants, type ButtonVariant } from './button.tsx'
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+	return (
+		<AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+	)
+}
+
+function AlertDialogPopup({
+	className,
+	children,
+	...props
+}: AlertDialogPrimitive.Popup.Props) {
+	return (
+		<AlertDialogPrimitive.Portal>
+			<AlertDialogPrimitive.Backdrop
+				data-slot="alert-dialog-backdrop"
+				className="data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50 bg-black/50"
+			/>
+			<AlertDialogPrimitive.Popup
+				data-slot="alert-dialog-content"
+				className={cn(
+					'bg-background data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border p-6 shadow-lg outline-none',
+					className,
+				)}
+				{...props}
+			>
+				{children}
+			</AlertDialogPrimitive.Popup>
+		</AlertDialogPrimitive.Portal>
+	)
+}
+
+function AlertDialogHeader({ className, ...props }: ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="alert-dialog-header"
+			className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+			{...props}
+		/>
+	)
+}
+
+function AlertDialogFooter({ className, ...props }: ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="alert-dialog-footer"
+			className={cn(
+				'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+				className,
+			)}
+			{...props}
+		/>
+	)
+}
+
+function AlertDialogTitle({
+	className,
+	...props
+}: AlertDialogPrimitive.Title.Props) {
+	return (
+		<AlertDialogPrimitive.Title
+			data-slot="alert-dialog-title"
+			className={cn('text-lg font-semibold', className)}
+			{...props}
+		/>
+	)
+}
+
+function AlertDialogDescription({
+	className,
+	...props
+}: AlertDialogPrimitive.Description.Props) {
+	return (
+		<AlertDialogPrimitive.Description
+			data-slot="alert-dialog-description"
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	)
+}
+
+function AlertDialogAction({
+	className,
+	variant = 'default',
+	...props
+}: AlertDialogPrimitive.Close.Props & { variant?: ButtonVariant['variant'] }) {
+	return (
+		<AlertDialogPrimitive.Close
+			data-slot="alert-dialog-action"
+			className={cn(buttonVariants({ variant }), className)}
+			{...props}
+		/>
+	)
+}
+
+function AlertDialogCancel({
+	className,
+	...props
+}: AlertDialogPrimitive.Close.Props) {
+	return (
+		<AlertDialogPrimitive.Close
+			data-slot="alert-dialog-cancel"
+			className={cn(buttonVariants({ variant: 'outline' }), className)}
+			{...props}
+		/>
+	)
+}
+
+export {
+	AlertDialog,
+	AlertDialogTrigger,
+	AlertDialogPopup,
+	AlertDialogHeader,
+	AlertDialogFooter,
+	AlertDialogTitle,
+	AlertDialogDescription,
+	AlertDialogAction,
+	AlertDialogCancel,
+}

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -1,7 +1,8 @@
-import { Form, Link } from 'react-router'
+import { Form, Link, useNavigation } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import {
 	AlertDialog,
+	AlertDialogAction,
 	AlertDialogCancel,
 	AlertDialogDescription,
 	AlertDialogFooter,
@@ -161,6 +162,11 @@ export default function ImportsIndexRoute({
 }
 
 function DisconnectStravaDialog() {
+	const navigation = useNavigation()
+	const isDisconnecting =
+		navigation.state !== 'idle' &&
+		navigation.formData?.get('intent') === 'disconnect-strava'
+
 	return (
 		<AlertDialog>
 			<AlertDialogTrigger
@@ -179,15 +185,19 @@ function DisconnectStravaDialog() {
 						removed. You can reconnect Strava at any time.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
-				<AlertDialogFooter>
-					<AlertDialogCancel>Keep connected</AlertDialogCancel>
-					<Form method="post">
-						<input type="hidden" name="intent" value="disconnect-strava" />
-						<Button type="submit" variant="destructive">
+				<Form method="post">
+					<input type="hidden" name="intent" value="disconnect-strava" />
+					<AlertDialogFooter>
+						<AlertDialogCancel type="button">Keep connected</AlertDialogCancel>
+						<AlertDialogAction
+							type="submit"
+							variant="destructive"
+							disabled={isDisconnecting}
+						>
 							Disconnect Strava
-						</Button>
-					</Form>
-				</AlertDialogFooter>
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</Form>
 			</AlertDialogPopup>
 		</AlertDialog>
 	)

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -1,5 +1,15 @@
 import { Form, Link } from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import {
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogPopup,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '#app/components/ui/alert-dialog.tsx'
 import { Badge } from '#app/components/ui/badge.tsx'
 import { Button, buttonVariants } from '#app/components/ui/button.tsx'
 import {
@@ -11,13 +21,17 @@ import {
 } from '#app/components/ui/card.tsx'
 import { isStravaOAuthConfigured } from '#app/integrations/strava/oauth.server.ts'
 import { STRAVA_PROVIDER } from '#app/integrations/strava/types.ts'
-import { getAccountConnection } from '#app/utils/account-connection.server.ts'
+import {
+	disconnectAccountConnection,
+	getAccountConnection,
+} from '#app/utils/account-connection.server.ts'
 import {
 	getInboxImports,
 	unlinkImport,
 	type InboxImport,
 } from '#app/utils/activity-import.server.ts'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { getDisciplineLabel } from '#app/utils/training.ts'
 import {
 	formatDuration,
@@ -52,6 +66,20 @@ export async function action({ request }: Route.ActionArgs) {
 
 	if (intent === 'unlink' && typeof importId === 'string') {
 		await unlinkImport(userId, importId)
+		return null
+	}
+
+	if (intent === 'disconnect-strava') {
+		await disconnectAccountConnection({
+			athleteId: userId,
+			provider: STRAVA_PROVIDER,
+		})
+		return redirectWithToast('/imports', {
+			title: 'Disconnected from Strava',
+			description:
+				'Promoted activities stay in your training history; inbox items were removed.',
+			type: 'success',
+		})
 	}
 
 	return null
@@ -98,6 +126,7 @@ export default function ImportsIndexRoute({
 										Sync now
 									</Button>
 								</Form>
+								<DisconnectStravaDialog />
 							</div>
 						) : (
 							<Form method="post" action="/integrations/strava/connect">
@@ -128,6 +157,39 @@ export default function ImportsIndexRoute({
 				</ul>
 			)}
 		</main>
+	)
+}
+
+function DisconnectStravaDialog() {
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger
+				render={
+					<Button variant="outline" size="sm">
+						Disconnect
+					</Button>
+				}
+			/>
+			<AlertDialogPopup>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Disconnect Strava?</AlertDialogTitle>
+					<AlertDialogDescription>
+						Your Strava activities that have become part of your training
+						history will stay. Items still waiting in your import inbox will be
+						removed. You can reconnect Strava at any time.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Keep connected</AlertDialogCancel>
+					<Form method="post">
+						<input type="hidden" name="intent" value="disconnect-strava" />
+						<Button type="submit" variant="destructive">
+							Disconnect Strava
+						</Button>
+					</Form>
+				</AlertDialogFooter>
+			</AlertDialogPopup>
+		</AlertDialog>
 	)
 }
 

--- a/app/utils/account-connection.server.test.ts
+++ b/app/utils/account-connection.server.test.ts
@@ -1,0 +1,232 @@
+import { faker } from '@faker-js/faker'
+import { expect, test } from 'vitest'
+import { createUser } from '#tests/db-utils.ts'
+import {
+	connectAccountConnection,
+	disconnectAccountConnection,
+	getAccountConnection,
+} from './account-connection.server.ts'
+import { prisma } from './db.server.ts'
+import { recomputeLoadFrom } from './load/snapshot.server.ts'
+
+const STRAVA = 'strava'
+
+async function createAthlete(tz = 'UTC') {
+	const userData = createUser()
+	const user = await prisma.user.create({
+		select: { id: true },
+		data: {
+			...userData,
+			athleteProfile: {
+				create: {
+					timezone: tz,
+					disciplineProfiles: {
+						create: [{ discipline: 'run', lthr: 160, maxHr: 185 }],
+					},
+				},
+			},
+		},
+	})
+	return user
+}
+
+function connectStrava(athleteId: string) {
+	return connectAccountConnection({
+		athleteId,
+		provider: STRAVA,
+		externalAthleteId: faker.string.numeric(8),
+		accessToken: faker.string.alphanumeric(24),
+		refreshToken: faker.string.alphanumeric(24),
+		expiresAt: new Date(Date.now() + 3_600_000),
+	})
+}
+
+function createInboxImport(
+	athleteId: string,
+	provider = STRAVA,
+	discipline = 'run',
+) {
+	const startedAt = new Date()
+	return prisma.activityImport.create({
+		data: {
+			athleteId,
+			externalProvider: provider,
+			externalId: faker.string.uuid(),
+			startedAt,
+			endedAt: new Date(startedAt.getTime() + 3_600_000),
+			durationSec: 3600,
+			discipline,
+			rawJson: '{}',
+		},
+		select: { id: true },
+	})
+}
+
+async function createPromotedImport(
+	athleteId: string,
+	scheduledAt: Date,
+	discipline = 'run',
+	hrAvg = 160,
+) {
+	const imp = await prisma.activityImport.create({
+		data: {
+			athleteId,
+			externalProvider: STRAVA,
+			externalId: faker.string.uuid(),
+			startedAt: scheduledAt,
+			endedAt: new Date(scheduledAt.getTime() + 3_600_000),
+			durationSec: 3600,
+			discipline,
+			hrAvg,
+			rawJson: '{}',
+		},
+		select: { id: true },
+	})
+	const session = await prisma.workoutSession.create({
+		data: {
+			userId: athleteId,
+			scheduledAt,
+			status: 'completed',
+			recordingId: imp.id,
+		},
+		select: { id: true },
+	})
+	await prisma.activityImport.update({
+		where: { id: imp.id },
+		data: { promotedSessionId: session.id },
+	})
+	return { importId: imp.id, sessionId: session.id }
+}
+
+test('disconnect removes the Account Connection row', async () => {
+	const athlete = await createAthlete()
+	await connectStrava(athlete.id)
+
+	const result = await disconnectAccountConnection({
+		athleteId: athlete.id,
+		provider: STRAVA,
+	})
+
+	expect(result.disconnected).toBe(true)
+	expect(await getAccountConnection(athlete.id, STRAVA)).toBeNull()
+})
+
+test('non-promoted inbox imports are removed on disconnect', async () => {
+	const athlete = await createAthlete()
+	await connectStrava(athlete.id)
+	await createInboxImport(athlete.id)
+	await createInboxImport(athlete.id)
+
+	const result = await disconnectAccountConnection({
+		athleteId: athlete.id,
+		provider: STRAVA,
+	})
+
+	expect(result.removedImports).toBe(2)
+	const remaining = await prisma.activityImport.count({
+		where: { athleteId: athlete.id, externalProvider: STRAVA },
+	})
+	expect(remaining).toBe(0)
+})
+
+test('promoted Recordings survive disconnect and stay resolvable', async () => {
+	const athlete = await createAthlete()
+	await connectStrava(athlete.id)
+	const today = new Date()
+	today.setUTCHours(12, 0, 0, 0)
+	const { importId, sessionId } = await createPromotedImport(athlete.id, today)
+	// plus an inbox item that should be cleaned up
+	await createInboxImport(athlete.id)
+
+	const result = await disconnectAccountConnection({
+		athleteId: athlete.id,
+		provider: STRAVA,
+	})
+
+	// Only the non-promoted import was removed.
+	expect(result.removedImports).toBe(1)
+
+	// The promoted import row survives, still pointing at its session.
+	const promoted = await prisma.activityImport.findUnique({
+		where: { id: importId },
+	})
+	expect(promoted).not.toBeNull()
+	expect(promoted!.promotedSessionId).toBe(sessionId)
+
+	// The Workout Session's recording linkage still resolves to the import.
+	const session = await prisma.workoutSession.findUnique({
+		where: { id: sessionId },
+		include: { recording: true },
+	})
+	expect(session!.recordingId).toBe(importId)
+	expect(session!.recording!.id).toBe(importId)
+})
+
+test('Load Snapshots are unchanged for days containing promoted imports', async () => {
+	const athlete = await createAthlete()
+	await connectStrava(athlete.id)
+	const today = new Date()
+	today.setUTCHours(12, 0, 0, 0)
+	const todayStr = today.toISOString().slice(0, 10)
+	await createPromotedImport(athlete.id, today)
+	await recomputeLoadFrom(athlete.id, todayStr)
+
+	const before = await prisma.loadSnapshot.findUnique({
+		where: { athleteId_date: { athleteId: athlete.id, date: todayStr } },
+	})
+	expect(before).not.toBeNull()
+	expect(before!.tssTotal).toBeGreaterThan(0)
+
+	await disconnectAccountConnection({ athleteId: athlete.id, provider: STRAVA })
+
+	const after = await prisma.loadSnapshot.findUnique({
+		where: { athleteId_date: { athleteId: athlete.id, date: todayStr } },
+	})
+	// Disconnect must not retroactively recompute Training Load.
+	expect(after).not.toBeNull()
+	expect(after!.tssTotal).toBe(before!.tssTotal)
+	expect(after!.computedAt.getTime()).toBe(before!.computedAt.getTime())
+})
+
+test('disconnect leaves other providers and other athletes untouched', async () => {
+	const athlete = await createAthlete()
+	const other = await createAthlete()
+	await connectStrava(athlete.id)
+	await createInboxImport(athlete.id, 'manual') // different provider
+	const othersImport = await createInboxImport(other.id, STRAVA) // different athlete
+
+	await disconnectAccountConnection({ athleteId: athlete.id, provider: STRAVA })
+
+	const manualSurvives = await prisma.activityImport.count({
+		where: { athleteId: athlete.id, externalProvider: 'manual' },
+	})
+	expect(manualSurvives).toBe(1)
+	const othersSurvives = await prisma.activityImport.findUnique({
+		where: { id: othersImport.id },
+	})
+	expect(othersSurvives).not.toBeNull()
+})
+
+test('disconnect is a no-op when there is no connection', async () => {
+	const athlete = await createAthlete()
+
+	const result = await disconnectAccountConnection({
+		athleteId: athlete.id,
+		provider: STRAVA,
+	})
+
+	expect(result.disconnected).toBe(false)
+	expect(result.removedImports).toBe(0)
+})
+
+test('reconnect after disconnect creates a fresh Account Connection', async () => {
+	const athlete = await createAthlete()
+	const first = await connectStrava(athlete.id)
+	await disconnectAccountConnection({ athleteId: athlete.id, provider: STRAVA })
+
+	const second = await connectStrava(athlete.id)
+
+	expect(second.id).not.toBe(first.id)
+	const connection = await getAccountConnection(athlete.id, STRAVA)
+	expect(connection!.status).toBe('active')
+})

--- a/app/utils/account-connection.server.ts
+++ b/app/utils/account-connection.server.ts
@@ -31,8 +31,20 @@ export function isAccountConnectionStatus(
 	return (ACCOUNT_CONNECTION_STATUSES as readonly string[]).includes(value)
 }
 
+/**
+ * External services trainm8 can hold an Account Connection for. The
+ * `AccountConnection.provider` column is a plain string in the schema (ADR
+ * 0014), but every code path that addresses a connection goes through this
+ * union so a typo fails at compile time rather than silently no-op'ing.
+ *
+ * Note this is narrower than `ActivityImport.externalProvider`, which also
+ * includes `'manual'` (file uploads) — those imports have no Account
+ * Connection behind them.
+ */
+export type Provider = 'strava' | 'garmin' | 'polar'
+
 /** The active Account Connection for an athlete/provider, if any. */
-export function getAccountConnection(athleteId: string, provider: string) {
+export function getAccountConnection(athleteId: string, provider: Provider) {
 	return prisma.accountConnection.findUnique({
 		where: { athleteId_provider: { athleteId, provider } },
 	})
@@ -52,7 +64,7 @@ export function connectAccountConnection({
 	expiresAt,
 }: {
 	athleteId: string
-	provider: string
+	provider: Provider
 	externalAthleteId: string
 	accessToken: string
 	refreshToken: string
@@ -98,7 +110,7 @@ export function disconnectAccountConnection({
 	provider,
 }: {
 	athleteId: string
-	provider: string
+	provider: Provider
 }) {
 	return prisma.$transaction(async (tx) => {
 		const { count: removedImports } = await tx.activityImport.deleteMany({

--- a/app/utils/account-connection.server.ts
+++ b/app/utils/account-connection.server.ts
@@ -73,3 +73,46 @@ export function connectAccountConnection({
 		update: tokens,
 	})
 }
+
+/**
+ * Athlete-initiated disconnect of an Account Connection (ADR 0012). In a single
+ * transaction this:
+ *
+ *  - hard-deletes the athlete's *non-promoted* Activity Imports for this
+ *    provider — inbox items that are no longer a viable promotion target once
+ *    the connection is gone — and
+ *  - removes the Account Connection row.
+ *
+ * Promoted imports (those carrying a `promotedSessionId`) survive untouched, so
+ * the Recordings attached to Workout Sessions — and their TSS contributions to
+ * Training Load — remain intact. Load Snapshots are deliberately NOT recomputed:
+ * the athlete's training history is treated as truthful and immutable to
+ * source-side changes.
+ *
+ * This is distinct from a source-initiated `status: 'revoked'`, which leaves
+ * non-promoted imports in place so the athlete can re-authorize. Only explicit
+ * disconnect triggers inbox cleanup.
+ */
+export function disconnectAccountConnection({
+	athleteId,
+	provider,
+}: {
+	athleteId: string
+	provider: string
+}) {
+	return prisma.$transaction(async (tx) => {
+		const { count: removedImports } = await tx.activityImport.deleteMany({
+			where: {
+				athleteId,
+				externalProvider: provider,
+				promotedSessionId: null,
+			},
+		})
+		const { count: removedConnections } = await tx.accountConnection.deleteMany(
+			{
+				where: { athleteId, provider },
+			},
+		)
+		return { removedImports, disconnected: removedConnections > 0 }
+	})
+}


### PR DESCRIPTION
## Summary

Implements Strava OAuth integration and Account Connection management for the trainm8 platform. This enables athletes to authorize their Strava accounts, automatically sync activities, and manage their connection lifecycle.

### Key Changes

**Core Infrastructure**
- Added `AccountConnection` model to Prisma schema with status state machine (`active`, `expired`, `revoked`, `error`)
- Implemented account connection lifecycle functions: `connectAccountConnection()`, `disconnectAccountConnection()`, `getAccountConnection()`
- Disconnect operation safely removes non-promoted inbox imports while preserving promoted activities and training load history

**Strava Integration**
- OAuth flow: `buildStravaAuthorization()`, `exchangeStravaCode()`, `verifyStravaOAuthState()` with CSRF protection
- Token management: `refreshStravaToken()` with automatic rotation and persistence
- Strava API client with authenticated requests and token refresh: `stravaApiGet()`, `getValidAccessToken()`
- Activity type mapping: `stravaTypeToDiscipline()` maps Strava types to trainm8 disciplines (run, bike, swim, strength, other)

**UI & Routes**
- New routes: `/integrations/strava/connect` (POST to start OAuth) and `/integrations/strava/callback` (OAuth callback handler)
- Updated `/imports` page with Strava connection status display and disconnect dialog
- Added `AlertDialog` component for confirmation dialogs
- Connection status badge and disconnect button with confirmation flow

**Configuration**
- Added environment variables: `STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, `STRAVA_REDIRECT_URI`
- Integration is optional—UI hides Strava affordance when unconfigured

### Design Notes

- Account Connection status is immutable at the database level (CHECK constraint)
- Disconnect is athlete-initiated and idempotent; distinct from source-initiated revocation
- Promoted imports (linked to Workout Sessions) survive disconnect; only inbox items are cleaned up
- Training Load snapshots are NOT retroactively recomputed on disconnect—training history is treated as immutable
- Token refresh happens transparently with a 60s safety margin before expiry
- Strava refresh tokens rotate on each refresh and are persisted immediately

## Test Plan

- Added comprehensive test suites:
  - `account-connection.server.test.ts`: Disconnect behavior, import cleanup, promoted import preservation, load snapshot immutability, provider isolation
  - `integrations.strava.callback.test.ts`: Happy path, CSRF validation, token exchange errors, consent denial
  - `integrations.strava.connect.test.ts`: OAuth redirect with scope and state cookie
  - `integrations.strava/discipline-map.test.ts`: Type-to-discipline mapping
- All tests pass with mocked Strava API responses
- Existing tests remain unaffected

## Checklist

- [x] Tests updated (added 4 new test files with comprehensive coverage)
- [x] Docs updated (environment variables documented in `.env.example` and `env.server.ts`)

https://claude.ai/code/session_01RVqCz1yNnd8DByQqfU3KpH