### PR TITLE
Strava 42-day Backfill Window as a queued job (#74)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,10 +45,10 @@ discipline, intensity, and quantity. _Avoid_: Interval, action
 
 **Discipline**: The sport modality for a workout or step (run, bike, swim,
 strength), with an additional import-only value `other` for Activity Imports
-from external categories the app does not model (hike, yoga, e-bike, alpine
-ski, etc.). Workout Templates and planned Steps cannot use `other`. Activity
-Imports marked `other` do not auto-promote and do not contribute to TSS or
-Training Load. _Avoid_: Activity type, sport type
+from external categories the app does not model (hike, yoga, e-bike, alpine ski,
+etc.). Workout Templates and planned Steps cannot use `other`. Activity Imports
+marked `other` do not auto-promote and do not contribute to TSS or Training
+Load. _Avoid_: Activity type, sport type
 
 **Intensity Target**: The prescribed effort level for a step, currently
 expressed via a fixed zone vocabulary (`easy`, `zone2`, `threshold`, `max`).
@@ -194,17 +194,16 @@ surfaced to the athlete. `revoked` means the source provider invalidated the
 authorization (athlete deauthorized at source, or refresh permanently failed)
 and requires athlete re-authorization. `error` is reserved for unexpected
 source-side failures requiring triage. Operational sync state (idle / actively
-fetching) is _not_ a `status` value — it is derived from the job queue.
-Manually uploaded Activity Imports use no Account Connection. _Avoid_:
-Integration, Connected Account, Service Connection, Provider Connection, Sync
-Source.
+fetching) is _not_ a `status` value — it is derived from the job queue. Manually
+uploaded Activity Imports use no Account Connection. _Avoid_: Integration,
+Connected Account, Service Connection, Provider Connection, Sync Source.
 
-**Backfill Window**: The 42-day historical window of Activity Imports
-retrieved from a newly-connected Account Connection, sized to match the CTL
-window so Training Load is meaningful from day one. Backfill runs as a
-background job (not synchronous with connect) and auto-promotes imports
-without a same-day planned Workout Session to recording-only Workout Sessions.
-_Avoid_: Initial sync, history sync.
+**Backfill Window**: The 42-day historical window of Activity Imports retrieved
+from a newly-connected Account Connection, sized to match the CTL window so
+Training Load is meaningful from day one. Backfill runs as a background job (not
+synchronous with connect) and auto-promotes imports without a same-day planned
+Workout Session to recording-only Workout Sessions. _Avoid_: Initial sync,
+history sync.
 
 **Activity Import**: A raw telemetry record imported from an external provider
 (Strava, Garmin, manual upload). Stored in an inbox; not rendered on the Tape
@@ -218,6 +217,12 @@ Session tile. _Avoid_: Execution, log (collides with Session Log), result
 **Promotion**: The act of linking an Activity Import to a Workout Session as its
 Recording (auto-matched on import, or chosen by the athlete). _Avoid_: Attach,
 import, sync
+
+**Job Queue**: The in-process background-work primitive (ADR 0013). A `Job` row
+carries a `kind` (which handler runs it) and an opaque JSON `payload`, with
+retry/backoff and a terminal `failed` state. A single polling worker drains the
+queue one job at a time. The Backfill Window is its first `kind`; webhook-fetch
+and reconciliation-poll reuse it. _Avoid_: Task queue, worker pool, scheduler
 
 ### Events and plan anchors
 
@@ -276,9 +281,9 @@ not duplicate them. _Avoid_: Race result row, achievement
   automatic. The athlete chooses which to promote and may discard the other.
 - An **Account Connection** can be disconnected. Disconnect stops further
   syncing and removes non-promoted **Activity Imports** from that provider, but
-  preserves **Recordings** (promoted imports) and their **TSS** contributions
-  to **Training Load** — the athlete's training history remains truthful.
-  Full deletion of historical data (right-to-be-forgotten) is a separate
+  preserves **Recordings** (promoted imports) and their **TSS** contributions to
+  **Training Load** — the athlete's training history remains truthful. Full
+  deletion of historical data (right-to-be-forgotten) is a separate
   athlete-initiated operation, not part of disconnect.
 - An **Account Connection** with `status: revoked` is distinct from disconnect:
   source-initiated revocation stops syncing but does _not_ immediately remove
@@ -287,10 +292,10 @@ not duplicate them. _Avoid_: Race result row, achievement
 - **Activity Imports** are snapshots taken at import time. When the source
   provider emits a later `update` for the same activity, non-promoted imports
   refresh to the new snapshot, but promoted **Recordings** are immutable to
-  source-side changes (the Recording belongs to the athlete's training
-  history). When the source emits a `delete`, non-promoted imports are
-  removed; promoted **Recordings** survive — the same truthfulness rule as
-  Account Connection disconnect.
+  source-side changes (the Recording belongs to the athlete's training history).
+  When the source emits a `delete`, non-promoted imports are removed; promoted
+  **Recordings** survive — the same truthfulness rule as Account Connection
+  disconnect.
 - The **Tape** renders **Workout Sessions** as tiles. **Activity Imports** that
   have not been promoted contribute to load metrics but are not Tape tiles.
 - A **Workout Session** may exist with no **Workout** attached when it was

--- a/app/integrations/strava/backfill.server.test.ts
+++ b/app/integrations/strava/backfill.server.test.ts
@@ -1,0 +1,178 @@
+import { invariant } from '@epic-web/invariant'
+import { faker } from '@faker-js/faker'
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { runStravaBackfill } from './backfill.server.ts'
+
+/**
+ * An athlete with an active Strava connection and a run threshold profile so
+ * HR-based TSS is computable for the mock "Morning Run" (avg HR 150).
+ */
+async function setupBackfillAthlete() {
+	const user = await prisma.user.create({
+		select: { id: true },
+		data: {
+			...createUser(),
+			athleteProfile: {
+				create: {
+					timezone: 'UTC',
+					disciplineProfiles: {
+						create: [{ discipline: 'run', lthr: 160, maxHr: 185 }],
+					},
+				},
+			},
+		},
+	})
+	const connection = await prisma.accountConnection.create({
+		data: {
+			athleteId: user.id,
+			provider: 'strava',
+			externalAthleteId: '12345678',
+			accessToken: 'initial_access',
+			refreshToken: 'initial_refresh',
+			expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+			status: 'active',
+			connectedAt: new Date('2026-05-28T00:00:00.000Z'),
+		},
+	})
+	return { user, connection }
+}
+
+async function createRunWorkout(userId: string) {
+	return prisma.workout.create({
+		select: { id: true },
+		data: {
+			title: faker.lorem.words(3),
+			discipline: 'run',
+			intent: 'endurance',
+			ownerId: userId,
+		},
+	})
+}
+
+test('backfill imports the activities in the window', async () => {
+	const { user } = await setupBackfillAthlete()
+
+	const result = await runStravaBackfill(user.id)
+
+	invariant(result.ok, 'expected a successful backfill')
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(4)
+	expect(imports.map((i) => i.discipline).sort()).toEqual([
+		'bike',
+		'other',
+		'run',
+		'swim',
+	])
+})
+
+test('an unmatched modeled activity is auto-promoted to a recording-only session', async () => {
+	const { user } = await setupBackfillAthlete()
+
+	await runStravaBackfill(user.id)
+
+	const bike = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, discipline: 'bike' },
+	})
+	expect(bike!.promotedSessionId).not.toBeNull()
+
+	const session = await prisma.workoutSession.findUnique({
+		where: { id: bike!.promotedSessionId! },
+	})
+	expect(session!.workoutId).toBeNull()
+	expect(session!.status).toBe('completed')
+	expect(session!.recordingId).toBe(bike!.id)
+})
+
+test('a matched activity links to the planned session instead of creating one', async () => {
+	const { user } = await setupBackfillAthlete()
+	const workout = await createRunWorkout(user.id)
+	// Planned run on the same UTC day as the mock "Morning Run" (2026-05-20).
+	const planned = await prisma.workoutSession.create({
+		select: { id: true },
+		data: {
+			userId: user.id,
+			workoutId: workout.id,
+			scheduledAt: new Date('2026-05-20T09:00:00.000Z'),
+		},
+	})
+
+	await runStravaBackfill(user.id)
+
+	const run = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, discipline: 'run' },
+	})
+	expect(run!.promotedSessionId).toBe(planned.id)
+
+	// No extra recording-only run session was created.
+	const runSessions = await prisma.workoutSession.count({
+		where: { userId: user.id, recordingId: run!.id },
+	})
+	expect(runSessions).toBe(1)
+})
+
+test('an "other" activity stays in the inbox, never auto-promoted', async () => {
+	const { user } = await setupBackfillAthlete()
+
+	await runStravaBackfill(user.id)
+
+	const other = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, discipline: 'other' },
+	})
+	expect(other!.promotedSessionId).toBeNull()
+	const otherSessions = await prisma.workoutSession.count({
+		where: { userId: user.id, recordingId: other!.id },
+	})
+	expect(otherSessions).toBe(0)
+})
+
+test('watermarks are stamped: lastSyncedAt to the latest activity, backfillCompletedAt set', async () => {
+	const { user, connection } = await setupBackfillAthlete()
+	const now = new Date('2026-05-28T12:00:00.000Z')
+
+	await runStravaBackfill(user.id, { now })
+
+	const after = await prisma.accountConnection.findUniqueOrThrow({
+		where: { id: connection.id },
+	})
+	// Latest mock activity is the Hike at 2026-05-23T17:00:00Z.
+	expect(after.lastSyncedAt!.toISOString()).toBe('2026-05-23T17:00:00.000Z')
+	expect(after.backfillCompletedAt!.toISOString()).toBe(now.toISOString())
+})
+
+test('Training Load is recomputed across the window after backfill', async () => {
+	const { user } = await setupBackfillAthlete()
+
+	await runStravaBackfill(user.id)
+
+	// The auto-promoted "Morning Run" (avg HR 150, LTHR 160) contributes hrTSS.
+	const snapshot = await prisma.loadSnapshot.findUnique({
+		where: { athleteId_date: { athleteId: user.id, date: '2026-05-20' } },
+	})
+	expect(snapshot).not.toBeNull()
+	expect(snapshot!.tssTotal).toBeGreaterThan(0)
+})
+
+test('backfill is idempotent on retry', async () => {
+	const { user } = await setupBackfillAthlete()
+
+	await runStravaBackfill(user.id)
+	const second = await runStravaBackfill(user.id)
+
+	invariant(second.ok, 'expected a successful re-run')
+	expect(second.created).toBe(0)
+	expect(second.promoted).toBe(0)
+
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(4)
+	// run + bike + swim auto-promoted (3 recording-only sessions); 'other' is not.
+	const sessions = await prisma.workoutSession.count({
+		where: { userId: user.id },
+	})
+	expect(sessions).toBe(3)
+})

--- a/app/integrations/strava/backfill.server.ts
+++ b/app/integrations/strava/backfill.server.ts
@@ -1,0 +1,162 @@
+import {
+	autoMatchImport,
+	createActivityImport,
+	promoteToNewSession,
+} from '#app/utils/activity-import.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { recomputeLoadFrom } from '#app/utils/load/snapshot.server.ts'
+import { StravaConnectionRevokedError } from './client.server.ts'
+import {
+	fetchStravaActivitiesAfter,
+	mapActivityToImportInput,
+} from './ingest.server.ts'
+import { STRAVA_PROVIDER } from './types.ts'
+
+/**
+ * The Backfill Window (#74). On connect, fetch the past 42 days of Strava
+ * activities — sized to match the CTL window so Training Load is meaningful from
+ * day one — and file each as an `ActivityImport`.
+ *
+ * Unlike manual sync, backfill is opinionated about promotion: a modeled-
+ * discipline activity with no same-day same-discipline planned session is
+ * auto-promoted to a recording-only Workout Session, so the athlete's history is
+ * populated without manual triage. `'other'` activities (ADR 0015) are never
+ * auto-promoted and wait in the inbox.
+ *
+ * Idempotent on retry: the unique `(provider, externalId)` guard skips activities
+ * already imported, and promotion is re-attempted for any import left unpromoted
+ * by an interrupted earlier run.
+ */
+
+/** The Backfill Window length, sized to the CTL (chronic load) window. */
+export const BACKFILL_WINDOW_DAYS = 42
+
+export type StravaBackfillResult =
+	| { ok: true; created: number; promoted: number }
+	| { ok: false; reason: 'not-connected' | 'revoked' }
+
+export async function runStravaBackfill(
+	athleteId: string,
+	{ now = new Date() }: { now?: Date } = {},
+): Promise<StravaBackfillResult> {
+	const connection = await prisma.accountConnection.findUnique({
+		where: { athleteId_provider: { athleteId, provider: STRAVA_PROVIDER } },
+	})
+	if (!connection) return { ok: false, reason: 'not-connected' }
+	if (connection.status === 'revoked') return { ok: false, reason: 'revoked' }
+
+	const timezone =
+		(
+			await prisma.athleteProfile.findUnique({
+				where: { userId: athleteId },
+				select: { timezone: true },
+			})
+		)?.timezone ?? 'UTC'
+
+	const windowStart = new Date(
+		now.getTime() - BACKFILL_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+	)
+	const afterUnixSec = Math.floor(windowStart.getTime() / 1000)
+
+	let activities
+	try {
+		activities = await fetchStravaActivitiesAfter(connection, afterUnixSec)
+	} catch (err) {
+		if (err instanceof StravaConnectionRevokedError) {
+			return { ok: false, reason: 'revoked' }
+		}
+		throw err
+	}
+
+	let created = 0
+	let promoted = 0
+	let latestActivityAt: Date | null = null
+
+	for (const activity of activities) {
+		const input = mapActivityToImportInput(activity)
+		if (latestActivityAt == null || input.startedAt > latestActivityAt) {
+			latestActivityAt = input.startedAt
+		}
+
+		const { importId, isNew } = await ensureImport(athleteId, input)
+		if (isNew) created++
+
+		// 'other' is import-only (ADR 0015): never auto-promoted.
+		if (input.discipline === 'other') continue
+
+		if (await ensurePromoted(athleteId, importId, timezone)) promoted++
+	}
+
+	await prisma.accountConnection.update({
+		where: { id: connection.id },
+		data: {
+			lastSyncedAt: latestActivityAt ?? connection.lastSyncedAt,
+			backfillCompletedAt: now,
+		},
+	})
+
+	// Recompute Training Load across the whole window so CTL/ATL/TSB reflect the
+	// backfilled history (covers both auto-promoted and auto-matched imports).
+	const windowStartDateStr = formatDateInTz(windowStart, timezone)
+	await recomputeLoadFrom(athleteId, windowStartDateStr)
+
+	return { ok: true, created, promoted }
+}
+
+/**
+ * Create the import, or report the pre-existing one on a unique-constraint hit
+ * so retries are idempotent.
+ */
+async function ensureImport(
+	athleteId: string,
+	input: ReturnType<typeof mapActivityToImportInput>,
+): Promise<{ importId: string; isNew: boolean }> {
+	try {
+		const created = await createActivityImport(athleteId, input)
+		return { importId: created.id, isNew: true }
+	} catch (err) {
+		if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
+			const existing = await prisma.activityImport.findUnique({
+				where: {
+					externalProvider_externalId: {
+						externalProvider: input.externalProvider,
+						externalId: input.externalId,
+					},
+				},
+				select: { id: true },
+			})
+			if (existing) return { importId: existing.id, isNew: false }
+		}
+		throw err
+	}
+}
+
+/**
+ * Ensure a modeled-discipline import is promoted: link it to a single matching
+ * planned session if one exists, otherwise create a recording-only session.
+ * No-ops (returns false) when the import is already promoted.
+ */
+async function ensurePromoted(
+	athleteId: string,
+	importId: string,
+	timezone: string,
+): Promise<boolean> {
+	const imp = await prisma.activityImport.findFirst({
+		where: { id: importId, athleteId },
+		select: { promotedSessionId: true },
+	})
+	if (!imp || imp.promotedSessionId != null) return false
+
+	const matched = await autoMatchImport(athleteId, importId, timezone)
+	if (!matched) await promoteToNewSession(athleteId, importId)
+	return true
+}
+
+function formatDateInTz(date: Date, timezone: string): string {
+	return new Intl.DateTimeFormat('en-CA', {
+		timeZone: timezone,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	}).format(date)
+}

--- a/app/integrations/strava/ingest.server.ts
+++ b/app/integrations/strava/ingest.server.ts
@@ -1,0 +1,89 @@
+import { type AccountConnection } from '@prisma/client'
+import { type ActivityImportInput } from '#app/utils/activity-import.server.ts'
+import { stravaApiGet } from './client.server.ts'
+import { stravaTypeToDiscipline } from './discipline-map.ts'
+import { createRateLimiter, STRAVA_RATE_LIMIT } from './rate-limit.ts'
+import { StravaActivitiesSchema, type StravaActivity } from './types.ts'
+
+/**
+ * Shared Strava ingest primitives used by both manual sync (#72) and the
+ * Backfill Window (#74): the pure activity → `ActivityImportInput` mapping and
+ * the paginated activity fetch. Keeping these in one place means the two trigger
+ * paths file identical imports and stay idempotent against each other.
+ */
+
+/** Strava caps `per_page` at 200; a modest page size keeps each request small. */
+const PER_PAGE = 100
+/** Safety cap so a misbehaving cursor can never loop forever. */
+const MAX_PAGES = 20
+
+/**
+ * Process-wide limiter shared by every Strava fetch (manual sync + backfill), so
+ * the per-app 600/15min budget is honoured across all athletes' activity. The
+ * single-worker design serialises concurrent backfills; this paces the requests
+ * within and across them.
+ */
+const stravaRateLimiter = createRateLimiter(STRAVA_RATE_LIMIT)
+
+/** Map one Strava summary activity onto the provider-neutral import shape. */
+export function mapActivityToImportInput(
+	activity: StravaActivity,
+): ActivityImportInput {
+	const discipline = stravaTypeToDiscipline(
+		activity.sport_type ?? activity.type ?? '',
+	)
+	const startedAt = new Date(activity.start_date)
+	const durationSec = activity.moving_time ?? activity.elapsed_time ?? 0
+	const elapsedSec = activity.elapsed_time ?? durationSec
+	const endedAt = new Date(startedAt.getTime() + elapsedSec * 1000)
+	const distanceM = activity.distance ?? null
+	const paceAvgSecPerKm =
+		distanceM != null && distanceM > 0 && durationSec > 0
+			? durationSec / (distanceM / 1000)
+			: null
+
+	return {
+		externalProvider: 'strava',
+		externalId: activity.id,
+		startedAt,
+		endedAt,
+		durationSec,
+		distanceM,
+		discipline,
+		hrAvg: activity.average_heartrate ?? null,
+		powerAvg: activity.average_watts ?? null,
+		paceAvgSecPerKm,
+		polyline: activity.map?.summary_polyline ?? null,
+		rawJson: JSON.stringify(activity),
+	}
+}
+
+type ConnectionRef = Pick<
+	AccountConnection,
+	'id' | 'accessToken' | 'refreshToken' | 'expiresAt'
+>
+
+/**
+ * Fetch all Strava activities created after `afterUnixSec`, walking pages until
+ * a short page (or the safety cap) ends the cursor. Token refresh and the
+ * revoked-grant signal are handled by the API client.
+ */
+export async function fetchStravaActivitiesAfter(
+	connection: ConnectionRef,
+	afterUnixSec: number,
+): Promise<StravaActivity[]> {
+	const all: StravaActivity[] = []
+	for (let page = 1; page <= MAX_PAGES; page++) {
+		await stravaRateLimiter.acquire()
+		const activities = StravaActivitiesSchema.parse(
+			await stravaApiGet(
+				connection,
+				`/athlete/activities?after=${afterUnixSec}&per_page=${PER_PAGE}&page=${page}`,
+			),
+		)
+		if (activities.length === 0) break
+		all.push(...activities)
+		if (activities.length < PER_PAGE) break
+	}
+	return all
+}

--- a/app/integrations/strava/rate-limit.test.ts
+++ b/app/integrations/strava/rate-limit.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import { createRateLimiter, type Clock } from './rate-limit.ts'
+
+/** A deterministic clock: `sleep` simply advances virtual time, never waits. */
+function fakeClock(): Clock & { ms: number } {
+	const clock = {
+		ms: 0,
+		now() {
+			return clock.ms
+		},
+		async sleep(ms: number) {
+			clock.ms += ms
+		},
+	}
+	return clock
+}
+
+test('acquisitions under the limit resolve without waiting', async () => {
+	const clock = fakeClock()
+	const limiter = createRateLimiter({ limit: 3, windowMs: 1000, clock })
+
+	await limiter.acquire()
+	await limiter.acquire()
+	await limiter.acquire()
+
+	// No virtual time passed: nothing had to wait.
+	expect(clock.ms).toBe(0)
+})
+
+test('throttles past the limit but drops nothing', async () => {
+	const clock = fakeClock()
+	const limiter = createRateLimiter({ limit: 2, windowMs: 1000, clock })
+
+	let completed = 0
+	// Fire 5 acquisitions through a budget of 2-per-1000ms window.
+	for (let i = 0; i < 5; i++) {
+		await limiter.acquire()
+		completed++
+	}
+
+	// All five eventually proceed — throttling delays, never drops.
+	expect(completed).toBe(5)
+	// The 3rd–5th had to wait for the window to roll: virtual time advanced.
+	expect(clock.ms).toBeGreaterThanOrEqual(2000)
+})

--- a/app/integrations/strava/rate-limit.ts
+++ b/app/integrations/strava/rate-limit.ts
@@ -1,0 +1,59 @@
+/**
+ * A sliding-window rate limiter for Strava's per-app budget (600 requests /
+ * 15 min — ADR 0013). `acquire()` resolves immediately while the window has
+ * room and otherwise waits until the oldest request ages out, so throttling
+ * delays calls rather than dropping them (#74).
+ *
+ * It is intentionally not concurrency-safe: the job worker runs single-threaded
+ * and fetches pages sequentially, so calls into a limiter are serialised. The
+ * single-worker design is what makes *concurrent* backfills queue behind one
+ * another rather than hammering the budget all at once.
+ */
+
+/** Injectable time source so tests can advance virtual time without waiting. */
+export type Clock = {
+	now: () => number
+	sleep: (ms: number) => Promise<void>
+}
+
+const realClock: Clock = {
+	now: () => Date.now(),
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}
+
+export type RateLimiter = { acquire: () => Promise<void> }
+
+export function createRateLimiter({
+	limit,
+	windowMs,
+	clock = realClock,
+}: {
+	limit: number
+	windowMs: number
+	clock?: Clock
+}): RateLimiter {
+	// Timestamps of requests still inside the current window, oldest first.
+	const hits: number[] = []
+
+	async function acquire(): Promise<void> {
+		for (;;) {
+			const now = clock.now()
+			const cutoff = now - windowMs
+			while (hits.length > 0 && hits[0]! <= cutoff) hits.shift()
+
+			if (hits.length < limit) {
+				hits.push(now)
+				return
+			}
+
+			// Wait just long enough for the oldest in-window request to expire.
+			const waitMs = hits[0]! + windowMs - now
+			await clock.sleep(Math.max(waitMs, 1))
+		}
+	}
+
+	return { acquire }
+}
+
+/** Strava's documented per-app limit: 600 requests per 15-minute window. */
+export const STRAVA_RATE_LIMIT = { limit: 600, windowMs: 15 * 60 * 1000 } as const

--- a/app/integrations/strava/sync.server.ts
+++ b/app/integrations/strava/sync.server.ts
@@ -3,13 +3,12 @@ import {
 	createActivityImport,
 } from '#app/utils/activity-import.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { stravaApiGet, StravaConnectionRevokedError } from './client.server.ts'
-import { stravaTypeToDiscipline } from './discipline-map.ts'
+import { StravaConnectionRevokedError } from './client.server.ts'
 import {
-	STRAVA_PROVIDER,
-	StravaActivitiesSchema,
-	type StravaActivity,
-} from './types.ts'
+	fetchStravaActivitiesAfter,
+	mapActivityToImportInput,
+} from './ingest.server.ts'
+import { STRAVA_PROVIDER } from './types.ts'
 
 /**
  * Manual "Sync now" (#72). Fetches the athlete's Strava activities created since
@@ -18,15 +17,13 @@ import {
  * mapped to disciplines via the provider-private table (ADR 0014); unmodeled
  * types collapse to `'other'` (ADR 0015) and are excluded from auto-match.
  *
+ * Unlike the Backfill Window (#74), manual sync only *links* imports to an
+ * existing planned session — it never auto-creates recording-only sessions.
+ *
  * Token refresh — including the rotated refresh token — is handled transparently
  * by the API client. A permanently revoked grant surfaces as a `revoked` result
  * so the surface can prompt the athlete to re-authorize.
  */
-
-/** Strava caps `per_page` at 200; a modest page size keeps each request small. */
-const PER_PAGE = 100
-/** Safety cap so a misbehaving cursor can never loop forever. */
-const MAX_PAGES = 20
 
 export type StravaSyncResult =
 	| { ok: true; created: number; skipped: number }
@@ -54,32 +51,36 @@ export async function syncStravaActivities(
 			})
 		)?.timezone ?? 'UTC'
 
-	let created = 0
-	let skipped = 0
+	let activities
 	try {
-		for (let page = 1; page <= MAX_PAGES; page++) {
-			const activities = StravaActivitiesSchema.parse(
-				await stravaApiGet(
-					connection,
-					`/athlete/activities?after=${after}&per_page=${PER_PAGE}&page=${page}`,
-				),
-			)
-			if (activities.length === 0) break
-
-			for (const activity of activities) {
-				const outcome = await importStravaActivity(athleteId, activity, timezone)
-				if (outcome === 'created') created++
-				else skipped++
-			}
-
-			// A short page means we've reached the end of the cursor.
-			if (activities.length < PER_PAGE) break
-		}
+		activities = await fetchStravaActivitiesAfter(connection, after)
 	} catch (err) {
 		if (err instanceof StravaConnectionRevokedError) {
 			return { ok: false, reason: 'revoked' }
 		}
 		throw err
+	}
+
+	let created = 0
+	let skipped = 0
+	for (const activity of activities) {
+		const input = mapActivityToImportInput(activity)
+		let importId: string
+		try {
+			importId = (await createActivityImport(athleteId, input)).id
+		} catch (err) {
+			if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
+				skipped++
+				continue
+			}
+			throw err
+		}
+		created++
+		// 'other' imports are excluded from auto-match (ADR 0015); they wait in the
+		// inbox for the athlete to handle manually.
+		if (input.discipline !== 'other') {
+			await autoMatchImport(athleteId, importId, timezone)
+		}
 	}
 
 	// Only advance the watermark on a fully successful pass.
@@ -89,58 +90,4 @@ export async function syncStravaActivities(
 	})
 
 	return { ok: true, created, skipped }
-}
-
-/**
- * Turn one Strava activity into an `ActivityImport`. Returns `'skipped'` when the
- * activity was already imported (the unique `(provider, externalId)` guard makes
- * re-syncs idempotent), otherwise `'created'`.
- */
-async function importStravaActivity(
-	athleteId: string,
-	activity: StravaActivity,
-	timezone: string,
-): Promise<'created' | 'skipped'> {
-	const discipline = stravaTypeToDiscipline(
-		activity.sport_type ?? activity.type ?? '',
-	)
-	const startedAt = new Date(activity.start_date)
-	const durationSec = activity.moving_time ?? activity.elapsed_time ?? 0
-	const elapsedSec = activity.elapsed_time ?? durationSec
-	const endedAt = new Date(startedAt.getTime() + elapsedSec * 1000)
-	const distanceM = activity.distance ?? null
-	const paceAvgSecPerKm =
-		distanceM != null && distanceM > 0 && durationSec > 0
-			? durationSec / (distanceM / 1000)
-			: null
-
-	let importRecord: { id: string }
-	try {
-		importRecord = await createActivityImport(athleteId, {
-			externalProvider: 'strava',
-			externalId: activity.id,
-			startedAt,
-			endedAt,
-			durationSec,
-			distanceM,
-			discipline,
-			hrAvg: activity.average_heartrate ?? null,
-			powerAvg: activity.average_watts ?? null,
-			paceAvgSecPerKm,
-			polyline: activity.map?.summary_polyline ?? null,
-			rawJson: JSON.stringify(activity),
-		})
-	} catch (err) {
-		if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
-			return 'skipped'
-		}
-		throw err
-	}
-
-	// 'other' imports are excluded from auto-match (ADR 0015); they wait in the
-	// inbox for the athlete to handle manually.
-	if (discipline !== 'other') {
-		await autoMatchImport(athleteId, importRecord.id, timezone)
-	}
-	return 'created'
 }

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -25,6 +25,7 @@ import { STRAVA_PROVIDER } from '#app/integrations/strava/types.ts'
 import {
 	disconnectAccountConnection,
 	getAccountConnection,
+	isBackfillInProgress,
 } from '#app/utils/account-connection.server.ts'
 import {
 	getInboxImports,
@@ -55,6 +56,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 		strava: {
 			configured: isStravaOAuthConfigured(),
 			connected: stravaConnection?.status === 'active',
+			backfillInProgress: isBackfillInProgress(stravaConnection),
 		},
 	}
 }
@@ -135,6 +137,18 @@ export default function ImportsIndexRoute({
 							</Form>
 						)}
 					</CardHeader>
+					{strava.backfillInProgress ? (
+						<CardContent>
+							<p
+								role="status"
+								className="text-muted-foreground text-sm"
+								data-testid="backfill-banner"
+							>
+								Importing 42 days of history from Strava… This runs in the
+								background; your activities will appear here shortly.
+							</p>
+						</CardContent>
+					) : null}
 				</Card>
 			) : null}
 

--- a/app/routes/integrations.strava.callback.test.ts
+++ b/app/routes/integrations.strava.callback.test.ts
@@ -83,6 +83,18 @@ test('happy path: persists an active Strava Account Connection', async () => {
 	expect(connection.connectedAt).toBeInstanceOf(Date)
 })
 
+test('enqueues a strava-backfill job for the athlete on connect', async () => {
+	const session = await setupUser()
+	const request = await setupRequest({ session })
+
+	await loader({ request, ...LOADER_ARGS_BASE })
+
+	const jobs = await prisma.job.findMany({ where: { kind: 'strava-backfill' } })
+	expect(jobs).toHaveLength(1)
+	expect(JSON.parse(jobs[0]!.payload)).toEqual({ athleteId: session.userId })
+	expect(jobs[0]!.status).toBe('pending')
+})
+
 test('rejects a state mismatch (CSRF) without creating a connection', async () => {
 	const session = await setupUser()
 	const request = await setupRequest({
@@ -143,7 +155,5 @@ test('denied consent at Strava redirects with an error toast', async () => {
 	const response = await loader({ request, ...LOADER_ARGS_BASE })
 
 	expect(response).toHaveRedirect('/imports')
-	await expect(response).toSendToast(
-		expect.objectContaining({ type: 'error' }),
-	)
+	await expect(response).toSendToast(expect.objectContaining({ type: 'error' }))
 })

--- a/app/routes/integrations.strava.callback.tsx
+++ b/app/routes/integrations.strava.callback.tsx
@@ -12,6 +12,7 @@ import {
 } from '#app/integrations/strava/types.ts'
 import { connectAccountConnection } from '#app/utils/account-connection.server.ts'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { enqueueJob } from '#app/utils/jobs/queue.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { type Route } from './+types/integrations.strava.callback.ts'
 
@@ -84,6 +85,13 @@ export async function loader({ request }: Route.LoaderArgs) {
 		accessToken: tokens.access_token,
 		refreshToken: tokens.refresh_token,
 		expiresAt: stravaExpiresAtToDate(tokens.expires_at),
+	})
+
+	// Kick off the 42-day Backfill Window out of band (#74). The callback must
+	// return well within Strava's timeout, so the fetch runs on the worker.
+	await enqueueJob({
+		kind: 'strava-backfill',
+		payload: { athleteId: userId },
 	})
 
 	return redirectWithToast(

--- a/app/utils/account-connection.server.test.ts
+++ b/app/utils/account-connection.server.test.ts
@@ -2,9 +2,11 @@ import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { createUser } from '#tests/db-utils.ts'
 import {
+	BACKFILL_EXPECTED_DURATION_MS,
 	connectAccountConnection,
 	disconnectAccountConnection,
 	getAccountConnection,
+	isBackfillInProgress,
 } from './account-connection.server.ts'
 import { prisma } from './db.server.ts'
 import { recomputeLoadFrom } from './load/snapshot.server.ts'
@@ -97,6 +99,44 @@ async function createPromotedImport(
 	})
 	return { importId: imp.id, sessionId: session.id }
 }
+
+test('backfill is in progress while uncompleted and the connection is fresh', () => {
+	const now = new Date('2026-05-29T12:00:00.000Z')
+	const connection = {
+		status: 'active',
+		backfillCompletedAt: null,
+		connectedAt: new Date(now.getTime() - 30_000), // 30s ago
+	}
+
+	expect(isBackfillInProgress(connection, now)).toBe(true)
+})
+
+test('backfill is no longer in progress once completed', () => {
+	const now = new Date('2026-05-29T12:00:00.000Z')
+	const connection = {
+		status: 'active',
+		backfillCompletedAt: new Date(now.getTime() - 1000),
+		connectedAt: new Date(now.getTime() - 30_000),
+	}
+
+	expect(isBackfillInProgress(connection, now)).toBe(false)
+})
+
+test('a stale uncompleted backfill stops showing as in progress', () => {
+	const now = new Date('2026-05-29T12:00:00.000Z')
+	const connection = {
+		status: 'active',
+		backfillCompletedAt: null,
+		// connected longer ago than the expected backfill duration → assume stalled
+		connectedAt: new Date(now.getTime() - BACKFILL_EXPECTED_DURATION_MS - 1000),
+	}
+
+	expect(isBackfillInProgress(connection, now)).toBe(false)
+})
+
+test('no connection is never in progress', () => {
+	expect(isBackfillInProgress(null, new Date())).toBe(false)
+})
 
 test('disconnect removes the Account Connection row', async () => {
 	const athlete = await createAthlete()

--- a/app/utils/account-connection.server.ts
+++ b/app/utils/account-connection.server.ts
@@ -1,3 +1,4 @@
+import { type AccountConnection } from '@prisma/client'
 import { prisma } from './db.server.ts'
 
 /**
@@ -42,6 +43,34 @@ export function isAccountConnectionStatus(
  * Connection behind them.
  */
 export type Provider = 'strava' | 'garmin' | 'polar'
+
+/**
+ * How long after connect we keep showing the Backfill Window as "in progress"
+ * before assuming the job stalled (#74). The banner clears either when
+ * `backfillCompletedAt` is stamped or once the connection ages past this.
+ */
+export const BACKFILL_EXPECTED_DURATION_MS = 10 * 60 * 1000
+
+/**
+ * Whether the initial 42-day Backfill Window is still running for a connection.
+ * True only for an active connection that hasn't recorded `backfillCompletedAt`
+ * and is younger than {@link BACKFILL_EXPECTED_DURATION_MS} — so a crashed or
+ * never-run backfill doesn't leave the banner up forever.
+ */
+export function isBackfillInProgress(
+	connection: Pick<
+		AccountConnection,
+		'status' | 'backfillCompletedAt' | 'connectedAt'
+	> | null,
+	now: Date = new Date(),
+): boolean {
+	if (!connection || connection.status !== 'active') return false
+	if (connection.backfillCompletedAt != null) return false
+	return (
+		now.getTime() - connection.connectedAt.getTime() <
+		BACKFILL_EXPECTED_DURATION_MS
+	)
+}
 
 /** The active Account Connection for an athlete/provider, if any. */
 export function getAccountConnection(athleteId: string, provider: Provider) {

--- a/app/utils/jobs/handlers.server.test.ts
+++ b/app/utils/jobs/handlers.server.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { jobHandlers } from './handlers.server.ts'
+import { enqueueJob, processNextJob } from './queue.server.ts'
+
+async function setupConnectedAthlete() {
+	const user = await prisma.user.create({
+		select: { id: true },
+		data: {
+			...createUser(),
+			athleteProfile: { create: { timezone: 'UTC' } },
+		},
+	})
+	await prisma.accountConnection.create({
+		data: {
+			athleteId: user.id,
+			provider: 'strava',
+			externalAthleteId: '12345678',
+			accessToken: 'initial_access',
+			refreshToken: 'initial_refresh',
+			expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+			status: 'active',
+			connectedAt: new Date('2026-05-28T00:00:00.000Z'),
+		},
+	})
+	return user
+}
+
+test('processing a strava-backfill job runs the backfill end-to-end', async () => {
+	const user = await setupConnectedAthlete()
+	const job = await enqueueJob({
+		kind: 'strava-backfill',
+		payload: { athleteId: user.id },
+	})
+
+	const result = await processNextJob(jobHandlers)
+
+	expect(result).toBe('processed')
+	const imports = await prisma.activityImport.count({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toBe(4)
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job.id } })
+	expect(row.status).toBe('completed')
+})

--- a/app/utils/jobs/handlers.server.ts
+++ b/app/utils/jobs/handlers.server.ts
@@ -1,0 +1,20 @@
+import { runStravaBackfill } from '#app/integrations/strava/backfill.server.ts'
+import { type JobHandlers } from './queue.server.ts'
+
+/**
+ * The registry of job kinds the worker knows how to run (ADR 0013). Adding a new
+ * background job is a matter of enqueuing its `kind` and registering a handler
+ * here — the queue and worker are otherwise unchanged.
+ */
+export const jobHandlers: JobHandlers = {
+	'strava-backfill': async (payload) => {
+		const athleteId = payload.athleteId
+		if (typeof athleteId !== 'string') {
+			throw new Error('strava-backfill job requires a string athleteId payload')
+		}
+		// `revoked` / `not-connected` are deliberate outcomes, not failures: the
+		// Account Connection carries the truth and a fresh connect re-enqueues a
+		// backfill. Only genuine fetch/DB errors throw and trigger retry.
+		await runStravaBackfill(athleteId)
+	},
+}

--- a/app/utils/jobs/queue.server.test.ts
+++ b/app/utils/jobs/queue.server.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import {
+	claimNextJob,
+	completeJob,
+	enqueueJob,
+	failJob,
+	processNextJob,
+} from './queue.server.ts'
+
+test('enqueued job can be claimed once', async () => {
+	await enqueueJob({ kind: 'strava-backfill', payload: { athleteId: 'a1' } })
+
+	const claimed = await claimNextJob()
+
+	expect(claimed).not.toBeNull()
+	expect(claimed!.kind).toBe('strava-backfill')
+	expect(claimed!.payload).toEqual({ athleteId: 'a1' })
+})
+
+test('a claimed job is not handed out a second time', async () => {
+	await enqueueJob({ kind: 'strava-backfill' })
+
+	const first = await claimNextJob()
+	const second = await claimNextJob()
+
+	expect(first).not.toBeNull()
+	expect(second).toBeNull()
+})
+
+test('completed job is terminal and never reclaimed', async () => {
+	await enqueueJob({ kind: 'strava-backfill' })
+	const job = await claimNextJob()
+
+	await completeJob(job!.id)
+
+	const reclaimed = await claimNextJob()
+	expect(reclaimed).toBeNull()
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job!.id } })
+	expect(row.status).toBe('completed')
+	expect(row.completedAt).not.toBeNull()
+})
+
+test('a failed job with attempts left is rescheduled into the future', async () => {
+	await enqueueJob({ kind: 'strava-backfill', maxAttempts: 3 })
+	const job = await claimNextJob()
+
+	await failJob(job!.id, new Error('boom'))
+
+	// Backoff pushes runAt out, so it is not immediately reclaimable.
+	expect(await claimNextJob()).toBeNull()
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job!.id } })
+	expect(row.status).toBe('pending')
+	expect(row.lastError).toBe('boom')
+	expect(row.runAt.getTime()).toBeGreaterThan(Date.now())
+})
+
+test('a job that exhausts maxAttempts becomes terminally failed', async () => {
+	await enqueueJob({ kind: 'strava-backfill', maxAttempts: 1 })
+	const job = await claimNextJob() // attempts -> 1, equal to maxAttempts
+
+	await failJob(job!.id, new Error('fatal'))
+
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job!.id } })
+	expect(row.status).toBe('failed')
+	expect(row.lastError).toBe('fatal')
+	// past runAt, but terminal status keeps it off the queue
+	const reclaimed = await claimNextJob()
+	expect(reclaimed).toBeNull()
+})
+
+test('processNextJob dispatches to the handler for the job kind and completes it', async () => {
+	const seen: Array<Record<string, unknown>> = []
+	const enqueued = await enqueueJob({
+		kind: 'strava-backfill',
+		payload: { athleteId: 'a1' },
+	})
+
+	const result = await processNextJob({
+		'strava-backfill': async (payload: Record<string, unknown>) => {
+			seen.push(payload)
+		},
+	})
+
+	expect(result).toBe('processed')
+	expect(seen).toEqual([{ athleteId: 'a1' }])
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: enqueued.id } })
+	expect(row.status).toBe('completed')
+})
+
+test('processNextJob returns idle when nothing is runnable', async () => {
+	expect(await processNextJob({})).toBe('idle')
+})
+
+test('a throwing handler fails the job for retry', async () => {
+	const enqueued = await enqueueJob({ kind: 'strava-backfill', maxAttempts: 3 })
+
+	const result = await processNextJob({
+		'strava-backfill': async () => {
+			throw new Error('handler exploded')
+		},
+	})
+
+	expect(result).toBe('processed')
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: enqueued.id } })
+	expect(row.status).toBe('pending')
+	expect(row.lastError).toBe('handler exploded')
+})
+
+test('a job with no registered handler fails rather than spinning', async () => {
+	const enqueued = await enqueueJob({ kind: 'mystery-kind', maxAttempts: 1 })
+
+	await processNextJob({})
+
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: enqueued.id } })
+	expect(row.status).toBe('failed')
+	expect(row.lastError).toMatch(/handler/i)
+})

--- a/app/utils/jobs/queue.server.ts
+++ b/app/utils/jobs/queue.server.ts
@@ -1,0 +1,137 @@
+import { type Job } from '@prisma/client'
+import { prisma } from '#app/utils/db.server.ts'
+
+/**
+ * The in-process job queue (ADR 0013). A deliberately domain-agnostic primitive:
+ * a `kind` selects a handler and an opaque JSON `payload` carries its arguments.
+ * Backfill (#74) is the first kind; webhook-fetch (#76) and reconciliation-poll
+ * (#77) reuse the same table and worker.
+ */
+
+/** A claimed job with its payload parsed from the stored JSON. */
+export type ClaimedJob = Omit<Job, 'payload'> & {
+	payload: Record<string, unknown>
+}
+
+/** Add a job to the queue. It becomes claimable immediately unless `runAt` is set. */
+export async function enqueueJob({
+	kind,
+	payload = {},
+	maxAttempts,
+	runAt,
+}: {
+	kind: string
+	payload?: Record<string, unknown>
+	maxAttempts?: number
+	runAt?: Date
+}): Promise<Job> {
+	return prisma.job.create({
+		data: {
+			kind,
+			payload: JSON.stringify(payload),
+			...(maxAttempts != null ? { maxAttempts } : {}),
+			...(runAt != null ? { runAt } : {}),
+		},
+	})
+}
+
+/**
+ * Atomically claim the oldest runnable pending job, moving it to `running`.
+ * Returns `null` when nothing is runnable. The claim updates by id so two
+ * concurrent workers can never take the same job.
+ */
+export async function claimNextJob(): Promise<ClaimedJob | null> {
+	const candidate = await prisma.job.findFirst({
+		where: { status: 'pending', runAt: { lte: new Date() } },
+		orderBy: { runAt: 'asc' },
+	})
+	if (!candidate) return null
+
+	const { count } = await prisma.job.updateMany({
+		where: { id: candidate.id, status: 'pending' },
+		data: {
+			status: 'running',
+			startedAt: new Date(),
+			attempts: { increment: 1 },
+		},
+	})
+	if (count === 0) return claimNextJob()
+
+	const claimed = await prisma.job.findUniqueOrThrow({
+		where: { id: candidate.id },
+	})
+	return {
+		...claimed,
+		payload: JSON.parse(claimed.payload) as Record<string, unknown>,
+	}
+}
+
+/** A handler runs one job kind. It receives the job's parsed JSON payload. */
+export type JobHandler = (payload: Record<string, unknown>) => Promise<void>
+
+/** Maps a job `kind` to the handler that runs it. */
+export type JobHandlers = Record<string, JobHandler>
+
+/**
+ * Claim the next runnable job and run its registered handler. On success the job
+ * is completed; a throwing handler (or a missing handler) fails the job, which
+ * either reschedules it with backoff or dead-letters it once attempts are spent.
+ * Returns `'idle'` when nothing was runnable so the worker loop can back off.
+ */
+export async function processNextJob(
+	handlers: JobHandlers,
+): Promise<'processed' | 'idle'> {
+	const job = await claimNextJob()
+	if (!job) return 'idle'
+
+	try {
+		const handler = handlers[job.kind]
+		if (!handler) {
+			throw new Error(`No handler registered for job kind "${job.kind}"`)
+		}
+		await handler(job.payload)
+		await completeJob(job.id)
+	} catch (error) {
+		await failJob(job.id, error)
+	}
+	return 'processed'
+}
+
+/** Mark a successfully-run job `completed`. Terminal — it is never reclaimed. */
+export async function completeJob(id: string): Promise<void> {
+	await prisma.job.update({
+		where: { id },
+		data: { status: 'completed', completedAt: new Date(), lastError: null },
+	})
+}
+
+/** Base unit for exponential backoff between retries. */
+const BACKOFF_BASE_MS = 1000
+
+/**
+ * Record a failed run. If attempts remain the job returns to `pending` with
+ * `runAt` pushed out by exponential backoff (`BACKOFF_BASE_MS * 2^attempts`);
+ * once `maxAttempts` is reached the job is terminal (`failed`).
+ */
+export async function failJob(id: string, error: unknown): Promise<void> {
+	const job = await prisma.job.findUniqueOrThrow({ where: { id } })
+	const message = error instanceof Error ? error.message : String(error)
+
+	if (job.attempts >= job.maxAttempts) {
+		await prisma.job.update({
+			where: { id },
+			data: { status: 'failed', lastError: message },
+		})
+		return
+	}
+
+	const delayMs = BACKOFF_BASE_MS * 2 ** job.attempts
+	await prisma.job.update({
+		where: { id },
+		data: {
+			status: 'pending',
+			lastError: message,
+			runAt: new Date(Date.now() + delayMs),
+		},
+	})
+}

--- a/app/utils/jobs/worker.server.ts
+++ b/app/utils/jobs/worker.server.ts
@@ -1,0 +1,47 @@
+import { jobHandlers } from './handlers.server.ts'
+import { processNextJob } from './queue.server.ts'
+
+/**
+ * The in-process job worker (ADR 0013). A single poller drains runnable jobs one
+ * at a time on a fixed interval. Single-concurrency is deliberate: it serialises
+ * concurrent backfills so they queue behind one another rather than hammering
+ * the source provider's rate budget all at once (#74).
+ */
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000
+
+/**
+ * Start polling the job queue. Returns a stop function (used on graceful
+ * shutdown). The interval is `unref`'d so the worker never keeps the process
+ * alive on its own.
+ */
+export function startJobWorker({
+	intervalMs = DEFAULT_POLL_INTERVAL_MS,
+}: { intervalMs?: number } = {}): () => void {
+	let draining = false
+	let stopped = false
+
+	async function tick() {
+		if (draining || stopped) return
+		draining = true
+		try {
+			// Drain every runnable job this tick so a burst doesn't wait one full
+			// interval per job; stop when the queue is idle or we've been stopped.
+			while (!stopped && (await processNextJob(jobHandlers)) === 'processed') {
+				/* keep draining */
+			}
+		} catch (error) {
+			console.error('[job-worker] tick failed', error)
+		} finally {
+			draining = false
+		}
+	}
+
+	const timer = setInterval(() => void tick(), intervalMs)
+	if (typeof timer.unref === 'function') timer.unref()
+
+	return () => {
+		stopped = true
+		clearInterval(timer)
+	}
+}

--- a/docs/adr/0013-strava-trigger-model.md
+++ b/docs/adr/0013-strava-trigger-model.md
@@ -1,71 +1,107 @@
 # Activity ingest trigger model: webhook + manual sync + reconciliation poll
 
-For the Strava integration (and future Garmin/Polar integrations), trainm8
-needs to decide how new activities flow from the source provider into our
-**Activity Import** inbox. The trigger model determines whether we need a
-public webhook endpoint, a job runner, polling state, and which UX latency the
-athlete experiences.
+For the Strava integration (and future Garmin/Polar integrations), trainm8 needs
+to decide how new activities flow from the source provider into our **Activity
+Import** inbox. The trigger model determines whether we need a public webhook
+endpoint, a job runner, polling state, and which UX latency the athlete
+experiences.
 
 ## Decision
 
 Use a three-layer hybrid trigger model from V1:
 
-1. **Webhook (primary)** — the source provider POSTs to our public endpoint
-   when activities are created, updated, or deleted. The webhook handler
-   verifies the signature, enqueues a fetch job, and responds within the
-   provider's 2-second timeout. The webhook is a notification only; the
-   activity body is fetched out of band.
+1. **Webhook (primary)** — the source provider POSTs to our public endpoint when
+   activities are created, updated, or deleted. The webhook handler verifies the
+   signature, enqueues a fetch job, and responds within the provider's 2-second
+   timeout. The webhook is a notification only; the activity body is fetched out
+   of band.
 2. **Manual "Sync now" (UX safety valve)** — the athlete can trigger an
    on-demand sync from the imports UI. Same code path as webhook fetch, but
    range-scoped by `lastSyncedAt`.
-3. **Reconciliation poll (sweep)** — a sparse scheduled job (daily) walks
-   recent activities for each active Account Connection and creates any
-   imports that were missed (webhook failures, downtime, lost events). Bounded
-   by the provider's per-app rate limit budget.
+3. **Reconciliation poll (sweep)** — a sparse scheduled job (daily) walks recent
+   activities for each active Account Connection and creates any imports that
+   were missed (webhook failures, downtime, lost events). Bounded by the
+   provider's per-app rate limit budget.
 
-All three layers feed the same job queue and the same downstream pipeline
-(fetch → create Activity Import → auto-match → SSE push).
+All three layers feed the same job queue and the same downstream pipeline (fetch
+→ create Activity Import → auto-match → SSE push).
 
 ## Considered options
 
 - **Manual sync only**: Rejected as the long-term default — fine MVP, but the
   athlete must remember to click "Sync now" before reflecting on a workout, and
   shipping a webhook layer later would force a parallel infrastructure rewrite.
-- **Polling only (every 15–30 min)**: Rejected — wastes the provider's
-  per-app rate budget on athletes who haven't trained today, and adds 30 minutes
-  of lag for athletes who have. With Strava's 600/15min cap shared across all
-  Account Connections, frequent polling does not scale.
+- **Polling only (every 15–30 min)**: Rejected — wastes the provider's per-app
+  rate budget on athletes who haven't trained today, and adds 30 minutes of lag
+  for athletes who have. With Strava's 600/15min cap shared across all Account
+  Connections, frequent polling does not scale.
 - **Webhook only (no reconciliation)**: Rejected — webhooks are not durable.
   Strava retries a small number of times and gives up. A 10-minute outage can
   silently drop activities across all athletes. Reconciliation is the safety
   net.
-- **Synchronous fetch inside the webhook handler**: Rejected — Strava expects
-  a 200 within 2 seconds, and an outbound API call plus DB writes is not
-  reliably within that budget. Decoupling via a queue is the only safe pattern.
+- **Synchronous fetch inside the webhook handler**: Rejected — Strava expects a
+  200 within 2 seconds, and an outbound API call plus DB writes is not reliably
+  within that budget. Decoupling via a queue is the only safe pattern.
 
 ## Consequences
 
 - A new job-queue primitive is required. Trainm8 has no job runner today; this
-  ADR commits us to introducing one. The minimum-viable shape is a
-  SQLite-backed table plus a polling worker started from the entry server,
-  scaling to BullMQ or Fly Machines schedules later.
+  ADR commits us to introducing one. The minimum-viable shape is a SQLite-backed
+  table plus a polling worker started from the entry server, scaling to BullMQ
+  or Fly Machines schedules later.
 - A new public route `/webhook/strava` is added. It must verify
-  `X-Strava-Signature` (HMAC-SHA256 of raw body with the webhook signing
-  secret) and reject unsigned requests. `hub.verify_token` is used only at
-  subscription registration time, not on subsequent events.
+  `X-Strava-Signature` (HMAC-SHA256 of raw body with the webhook signing secret)
+  and reject unsigned requests. `hub.verify_token` is used only at subscription
+  registration time, not on subsequent events.
 - Local dev cannot receive Strava webhooks at `localhost`. An env-conditional
   path falls back to "manual sync + poll" in development; ngrok or similar is
   optional for end-to-end webhook testing.
-- Strava webhooks carry only `{ object_id, owner_id, aspect_type }`. Each
-  event triggers a follow-up `GET /activities/:id` call that costs a slot in
-  the per-app 600/15min rate budget. Budgeting / backoff is the worker's job.
-- `Account Connection.lastSyncedAt` is updated by all three triggers and is
-  the high-water mark used by manual sync and reconciliation.
-- The same queue and the same pipeline serve **Backfill Window** jobs on
-  initial connect. One queue, three trigger sources (webhook, manual sync,
+- Strava webhooks carry only `{ object_id, owner_id, aspect_type }`. Each event
+  triggers a follow-up `GET /activities/:id` call that costs a slot in the
+  per-app 600/15min rate budget. Budgeting / backoff is the worker's job.
+- `Account Connection.lastSyncedAt` is updated by all three triggers and is the
+  high-water mark used by manual sync and reconciliation.
+- The same queue and the same pipeline serve **Backfill Window** jobs on initial
+  connect. One queue, three trigger sources (webhook, manual sync,
   reconciliation), one job kind (`fetch activity by external id`).
 - Strava access tokens last 6 hours and refresh tokens rotate on each refresh.
-  Token refresh is the worker's responsibility, performed on 401 or
-  proactively before expiry; the new refresh token must be persisted.
+  Token refresh is the worker's responsibility, performed on 401 or proactively
+  before expiry; the new refresh token must be persisted.
 - The reconciliation poll cadence (daily) is a knob we expect to tune once we
   have data on webhook reliability.
+
+## Amendment (#74): job-queue technology
+
+The Backfill Window (#74) is the first consumer of the job-queue primitive this
+ADR committed to, so the implementation choice is recorded here.
+
+- **Technology: a SQLite-backed `Job` table polled by an in-process worker.** No
+  Redis, no BullMQ — the queue lives in the same SQLite database as the rest of
+  the app and the worker is started from the entry server (`server/index.ts`)
+  after `app.listen()`, stopped via `closeWithGrace`. This keeps trainm8 a
+  single-process deploy. BullMQ + Redis or Fly Machines remain the documented
+  escape hatch if queue volume ever outgrows polling.
+- **Generic, not Strava-specific.** The `Job` model is domain-agnostic: a `kind`
+  string selects a handler from a registry and an opaque JSON `payload` carries
+  its arguments. `strava-backfill` is the first kind; webhook-fetch (#76) and
+  reconciliation-poll (#77) register their own handlers against the same table
+  and worker.
+- **Lifecycle & retries.** `status` moves pending → running → completed |
+  failed. `claimNextJob` atomically flips a single row to `running` (claim by
+  id, so two workers never take the same job). A throwing handler calls
+  `failJob`, which either returns the job to `pending` with `runAt` pushed out
+  by exponential backoff (`1s * 2^attempts`) or, once `maxAttempts` is reached,
+  marks it terminally `failed`. A job with no registered handler fails rather
+  than spinning.
+- **Concurrency = 1, by design.** The worker drains jobs sequentially. This is
+  what makes multiple concurrent backfills _queue_ behind one another instead of
+  hammering Strava's per-app budget all at once. Within the budget, a shared
+  sliding-window rate limiter (600 req / 15 min) paces the activity fetches so
+  throttling delays requests rather than dropping activities.
+- **Backfill specifics.** `strava-backfill` fetches the 42-day window, files
+  `ActivityImport` rows (idempotent via the unique `(provider, externalId)`
+  guard), auto-promotes unmatched modeled-discipline imports to recording-only
+  Workout Sessions (`'other'` excluded, ADR 0015), stamps `lastSyncedAt` to the
+  latest activity and `backfillCompletedAt` on success, and recomputes Training
+  Load across the window. Retries converge: an import left unpromoted by an
+  interrupted run is promoted on the next attempt.

--- a/prisma/migrations/20260528200421_add_job_queue/migration.sql
+++ b/prisma/migrations/20260528200421_add_job_queue/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "kind" TEXT NOT NULL,
+    "payload" TEXT NOT NULL DEFAULT '{}',
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "runAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastError" TEXT,
+    "startedAt" DATETIME,
+    "completedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "Job_status_runAt_idx" ON "Job"("status", "runAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -407,6 +407,31 @@ model ActivityImport {
   @@index([athleteId])
 }
 
+/// A unit of background work for the in-process job worker (ADR 0013). The queue
+/// is deliberately domain-agnostic: `kind` selects a handler and `payload` is an
+/// opaque JSON blob the handler interprets. Backfill (#74) is the first kind;
+/// webhook-fetch (#76) and reconciliation-poll (#77) reuse the same table.
+///
+/// `status` lifecycle: pending → running → completed | failed. A failed run with
+/// attempts remaining returns to `pending` with `runAt` pushed into the future
+/// (exponential backoff); exhausting `maxAttempts` is terminal (`failed`).
+model Job {
+  id          String    @id @default(cuid())
+  kind        String // e.g. 'strava-backfill'
+  payload     String    @default("{}") // JSON-encoded handler arguments
+  status      String    @default("pending") // 'pending' | 'running' | 'completed' | 'failed'
+  attempts    Int       @default(0)
+  maxAttempts Int       @default(5)
+  runAt       DateTime  @default(now()) // earliest time the job may be claimed (backoff cursor)
+  lastError   String?
+  startedAt   DateTime? // when the current/last run was claimed
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([status, runAt])
+}
+
 model LoadSnapshot {
   id              String   @id @default(cuid())
   athleteId       String

--- a/server/index.ts
+++ b/server/index.ts
@@ -233,7 +233,14 @@ ${styleText('bold', 'Press Ctrl+C to stop')}
 	)
 })
 
+// Start the in-process job worker that drains the queue (Strava backfill #74,
+// and future webhook/reconciliation jobs). Imported dynamically so it only
+// loads once the server is actually running.
+const { startJobWorker } = await import('#app/utils/jobs/worker.server.ts')
+const stopJobWorker = startJobWorker()
+
 closeWithGrace(async ({ err }) => {
+	stopJobWorker()
 	await new Promise((resolve, reject) => {
 		server.close((e) => (e ? reject(e) : resolve('ok')))
 	})


### PR DESCRIPTION
Closes #74.

Implements Phase 2 of the Strava integration: a generic in-process job queue and the `strava-backfill` job that populates 42 days of history on connect.

## What's here (TDD, slice by slice)

- **Job queue primitive** (`app/utils/jobs/`): SQLite-backed `Job` model (`kind` + JSON `payload`), `enqueue`/`claimNextJob` (atomic, no double-claim)/`completeJob`/`failJob` (exponential backoff → terminal `failed`), and `processNextJob` dispatch-by-kind. A single poller (`worker.server.ts`) drains the queue sequentially, started from `server/index.ts` after `app.listen()` and stopped on graceful shutdown.
- **`strava-backfill` handler** (`backfill.server.ts`): fetches the 42-day window, files `ActivityImport`s (idempotent via the unique guard), auto-promotes unmatched modeled-discipline imports to recording-only Workout Sessions (`'other'` excluded per ADR 0015), links matched imports to planned sessions, stamps `lastSyncedAt` (latest activity) + `backfillCompletedAt`, and recomputes Training Load across the window. Retries converge.
- **Wiring**: OAuth callback enqueues the job out of band; handler registry maps the kind.
- **Banner**: `isBackfillInProgress()` drives an "Importing 42 days…" banner on the Imports surface; clears on completion or once the connection ages past the expected duration.
- **Rate limiting**: shared sliding-window limiter (600/15min) paces fetches; single-worker concurrency queues concurrent backfills.
- **Refactor**: extracted shared Strava ingest (mapping + paginated fetch) reused by manual sync and backfill.
- **Docs**: ADR 0013 amended with the chosen queue tech (generic SQLite table + poller); `Job Queue` added to CONTEXT.md.

## Acceptance criteria

All 11 met. Queue primitive ✓, ADR amended ✓, backfill job ✓, auto-promotion ✓, `'other'` stays in inbox ✓, `lastSyncedAt`/`backfillCompletedAt` ✓, banner ✓, rate-limit throttling ✓, load recompute ✓, tests cover imports/promotion/other/throttle/idempotency ✓.

## Tests

44 tests across queue, backfill, ingest/sync, rate-limit, handler registry, account-connection, and the OAuth callback. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)