### PR TITLE
feat: SSE pushes new Activity Imports to open tabs live (#75)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,6 +224,13 @@ retry/backoff and a terminal `failed` state. A single polling worker drains the
 queue one job at a time. The Backfill Window is its first `kind`; webhook-fetch
 and reconciliation-poll reuse it. _Avoid_: Task queue, worker pool, scheduler
 
+**Live Imports Stream**: The per-athlete Server-Sent Events channel that pushes
+"a new Activity Import landed" to the athlete's open Imports tabs so the inbox
+revalidates without a page reload (ADR 0013, #75). Every `createActivityImport`
+publishes to the owning athlete's stream — manual sync, Backfill Window, file
+upload, and future webhook ingest all flow through the one publisher. _Avoid_:
+WebSocket, push notification, socket
+
 ### Events and plan anchors
 
 **Event**: An athlete's anchor point on the right side of The Tape — a race, a

--- a/app/routes/imports._index.tsx
+++ b/app/routes/imports._index.tsx
@@ -33,6 +33,7 @@ import {
 	type InboxImport,
 } from '#app/utils/activity-import.server.ts'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { useRevalidateOnImportEvent } from '#app/utils/imports-events.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { getDisciplineLabel } from '#app/utils/training.ts'
 import {
@@ -92,6 +93,10 @@ export default function ImportsIndexRoute({
 	loaderData,
 }: Route.ComponentProps) {
 	const { imports, strava } = loaderData
+
+	// Refresh the inbox live as new imports land (manual sync, backfill, or a
+	// future webhook) without a page reload (#75).
+	useRevalidateOnImportEvent()
 
 	return (
 		<main className="container py-10">

--- a/app/routes/resources/imports-events.tsx
+++ b/app/routes/resources/imports-events.tsx
@@ -1,0 +1,27 @@
+import { eventStream } from 'remix-utils/sse/server'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { subscribeActivityImportCreated } from '#app/utils/imports-events.server.ts'
+import { IMPORT_CREATED_EVENT } from '#app/utils/imports-events.ts'
+import { type Route } from './+types/imports-events.ts'
+
+/**
+ * Per-athlete Server-Sent Events stream for live Activity Import updates (#75).
+ *
+ * The stream is scoped to the authenticated athlete via the same session auth as
+ * every other route, so athlete A's events never reach athlete B's tab. The
+ * connection stays open until the client navigates away or the request aborts,
+ * at which point the subscription is torn down.
+ */
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+
+	return eventStream(request.signal, (send) => {
+		const unsubscribe = subscribeActivityImportCreated(userId, () => {
+			// The payload is unused by the client beyond signalling "something
+			// changed" — a timestamp keeps consecutive events distinct so the
+			// browser's EventSource state advances and the revalidation fires.
+			send({ event: IMPORT_CREATED_EVENT, data: String(Date.now()) })
+		})
+		return () => unsubscribe()
+	})
+}

--- a/app/utils/activity-import.server.ts
+++ b/app/utils/activity-import.server.ts
@@ -1,4 +1,5 @@
 import { prisma } from './db.server.ts'
+import { publishActivityImportCreated } from './imports-events.server.ts'
 import { recomputeLoadFrom } from './load/snapshot.server.ts'
 
 async function triggerRecomputeForImport(importId: string): Promise<void> {
@@ -49,7 +50,7 @@ export async function createActivityImport(
 	athleteId: string,
 	input: ActivityImportInput,
 ) {
-	return prisma.activityImport.create({
+	const created = await prisma.activityImport.create({
 		data: {
 			athleteId,
 			externalProvider: input.externalProvider,
@@ -67,6 +68,12 @@ export async function createActivityImport(
 		},
 		select: { id: true, startedAt: true, endedAt: true, discipline: true },
 	})
+	// Push a live "new import landed" event to the athlete's open Imports tabs
+	// (#75). This is the single insert choke point, so manual sync (#72),
+	// backfill (#74), file upload, and future webhook (#76) all publish here
+	// after a successful insert without each call site having to remember to.
+	publishActivityImportCreated(athleteId)
+	return created
 }
 
 export async function getInboxImports(athleteId: string) {

--- a/app/utils/imports-events.server.test.ts
+++ b/app/utils/imports-events.server.test.ts
@@ -1,0 +1,95 @@
+import { expect, test, vi } from 'vitest'
+import { createUser } from '#tests/db-utils.ts'
+import {
+	createActivityImport,
+	type ActivityImportInput,
+} from './activity-import.server.ts'
+import { prisma } from './db.server.ts'
+import {
+	publishActivityImportCreated,
+	subscribeActivityImportCreated,
+} from './imports-events.server.ts'
+
+function importInput(
+	overrides: Partial<ActivityImportInput> = {},
+): ActivityImportInput {
+	const startedAt = new Date('2026-05-20T06:00:00.000Z')
+	return {
+		externalProvider: 'manual',
+		externalId: `ext-${Math.random().toString(36).slice(2)}`,
+		startedAt,
+		endedAt: new Date(startedAt.getTime() + 3600 * 1000),
+		durationSec: 3600,
+		discipline: 'run',
+		rawJson: '{}',
+		...overrides,
+	}
+}
+
+async function createAthlete() {
+	return prisma.user.create({ data: { ...createUser() }, select: { id: true } })
+}
+
+test('publish/subscribe delivers an event to the athlete listener', () => {
+	const listener = vi.fn()
+	const unsubscribe = subscribeActivityImportCreated('athlete-1', listener)
+
+	publishActivityImportCreated('athlete-1')
+
+	expect(listener).toHaveBeenCalledTimes(1)
+	unsubscribe()
+})
+
+test('unsubscribe detaches the listener', () => {
+	const listener = vi.fn()
+	const unsubscribe = subscribeActivityImportCreated('athlete-1', listener)
+	unsubscribe()
+
+	publishActivityImportCreated('athlete-1')
+
+	expect(listener).not.toHaveBeenCalled()
+})
+
+test('creating an Activity Import emits an event for the owning athlete', async () => {
+	const athlete = await createAthlete()
+	const listener = vi.fn()
+	const unsubscribe = subscribeActivityImportCreated(athlete.id, listener)
+
+	await createActivityImport(athlete.id, importInput())
+
+	expect(listener).toHaveBeenCalledTimes(1)
+	unsubscribe()
+})
+
+test('per-athlete isolation: athlete B does not receive athlete A events', async () => {
+	const [athleteA, athleteB] = await Promise.all([
+		createAthlete(),
+		createAthlete(),
+	])
+	const listenerA = vi.fn()
+	const listenerB = vi.fn()
+	const unsubA = subscribeActivityImportCreated(athleteA.id, listenerA)
+	const unsubB = subscribeActivityImportCreated(athleteB.id, listenerB)
+
+	await createActivityImport(athleteA.id, importInput())
+
+	expect(listenerA).toHaveBeenCalledTimes(1)
+	expect(listenerB).not.toHaveBeenCalled()
+	unsubA()
+	unsubB()
+})
+
+test('a failed insert (duplicate) does not emit', async () => {
+	const athlete = await createAthlete()
+	const input = importInput({ externalId: 'dup-1' })
+	await createActivityImport(athlete.id, input)
+
+	const listener = vi.fn()
+	const unsubscribe = subscribeActivityImportCreated(athlete.id, listener)
+
+	// Same (externalProvider, externalId) violates the unique guard and throws.
+	await expect(createActivityImport(athlete.id, input)).rejects.toThrow()
+
+	expect(listener).not.toHaveBeenCalled()
+	unsubscribe()
+})

--- a/app/utils/imports-events.server.ts
+++ b/app/utils/imports-events.server.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from 'node:events'
+import { remember } from '@epic-web/remember'
+
+/**
+ * In-process publisher for "a new Activity Import landed" events (#75).
+ *
+ * Server-Sent Events push these to the athlete's open Imports tabs so the inbox
+ * refreshes live. SSE was chosen over a bidirectional socket because we only
+ * need unidirectional server→browser push, session-cookie auth comes for free
+ * with same-origin `EventSource`, and there is no extra dependency or sticky
+ * session requirement (ADR 0013 / issue #75).
+ *
+ * The emitter is keyed per athlete: each event name is an `athleteId`, so a
+ * subscriber for athlete A never observes athlete B's inserts. Emitting for an
+ * athlete with no open tabs is a harmless no-op.
+ *
+ * This is a single-process publisher. It is the right shape for the current
+ * single-machine deployment; a multi-instance future would swap the emitter for
+ * a shared transport (e.g. Postgres LISTEN/NOTIFY or Redis pub/sub) behind the
+ * same `publish` / `subscribe` surface.
+ */
+
+const emitter = remember('imports-event-emitter', () => {
+	const instance = new EventEmitter()
+	// One listener per open tab; lift the default ceiling so a busy athlete with
+	// many tabs does not trip Node's max-listeners leak warning.
+	instance.setMaxListeners(0)
+	return instance
+})
+
+/** Notify the owning athlete's open tabs that a new Activity Import was created. */
+export function publishActivityImportCreated(athleteId: string): void {
+	emitter.emit(athleteId)
+}
+
+/**
+ * Subscribe to "Activity Import created" events for a single athlete. Returns an
+ * unsubscribe function that detaches the listener — call it when the SSE stream
+ * closes so the emitter does not retain listeners for disconnected tabs.
+ */
+export function subscribeActivityImportCreated(
+	athleteId: string,
+	listener: () => void,
+): () => void {
+	emitter.on(athleteId, listener)
+	return () => {
+		emitter.off(athleteId, listener)
+	}
+}

--- a/app/utils/imports-events.test.tsx
+++ b/app/utils/imports-events.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react'
+import { useEventSource } from 'remix-utils/sse/react'
+import { expect, test, vi, beforeEach } from 'vitest'
+import { useRevalidateOnImportEvent } from './imports-events.ts'
+
+const revalidate = vi.fn()
+
+vi.mock('react-router', () => ({
+	useRevalidator: () => ({ revalidate }),
+}))
+
+vi.mock('remix-utils/sse/react', () => ({
+	useEventSource: vi.fn(),
+}))
+
+const mockUseEventSource = vi.mocked(useEventSource)
+
+beforeEach(() => {
+	revalidate.mockClear()
+})
+
+test('does not revalidate before any event arrives', () => {
+	mockUseEventSource.mockReturnValue(null)
+
+	renderHook(() => useRevalidateOnImportEvent())
+
+	expect(revalidate).not.toHaveBeenCalled()
+})
+
+test('revalidates when a new import event arrives', () => {
+	mockUseEventSource.mockReturnValue(null)
+	const { rerender } = renderHook(() => useRevalidateOnImportEvent())
+	expect(revalidate).not.toHaveBeenCalled()
+
+	// A push advances the EventSource state to a fresh payload.
+	mockUseEventSource.mockReturnValue('1716187200000')
+	rerender()
+
+	expect(revalidate).toHaveBeenCalledTimes(1)
+})
+
+test('revalidates again on each subsequent event', () => {
+	mockUseEventSource.mockReturnValue('1716187200000')
+	const { rerender } = renderHook(() => useRevalidateOnImportEvent())
+	expect(revalidate).toHaveBeenCalledTimes(1)
+
+	mockUseEventSource.mockReturnValue('1716187260000')
+	rerender()
+
+	expect(revalidate).toHaveBeenCalledTimes(2)
+})

--- a/app/utils/imports-events.ts
+++ b/app/utils/imports-events.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useRevalidator } from 'react-router'
+import { useEventSource } from 'remix-utils/sse/react'
+
+/**
+ * Client-side counterpart to `imports-events.server.ts` (#75). The Imports
+ * surface opens an `EventSource` to the resource route below; when a new
+ * Activity Import lands for the athlete, the server pushes an event and the tab
+ * revalidates its loader data so the inbox refreshes without a page reload.
+ *
+ * These constants are shared by the resource route (server) and the hook
+ * (client), so they live in this isomorphic module rather than the `.server`
+ * file.
+ */
+
+/** Resource route that serves the per-athlete `text/event-stream`. */
+export const IMPORTS_EVENTS_PATH = '/resources/imports-events'
+
+/** Named SSE event emitted when a new Activity Import is created. */
+export const IMPORT_CREATED_EVENT = 'import-created'
+
+/**
+ * Subscribe the current tab to live Activity Import events and revalidate the
+ * route's loader data whenever one arrives. `EventSource` auto-reconnects on
+ * transient disconnects (browser default), and `useEventSource` closes the
+ * stream when the component unmounts.
+ */
+export function useRevalidateOnImportEvent(): void {
+	const lastEvent = useEventSource(IMPORTS_EVENTS_PATH, {
+		event: IMPORT_CREATED_EVENT,
+	})
+	const { revalidate } = useRevalidator()
+
+	useEffect(() => {
+		// `null` is the initial "no event yet" value; only revalidate on a real
+		// push. Each event carries a fresh payload so repeats still re-trigger.
+		if (lastEvent !== null) {
+			void revalidate()
+		}
+	}, [lastEvent, revalidate])
+}


### PR DESCRIPTION
Add a per-athlete Server-Sent Events channel so the Imports inbox refreshes
live as new Activity Imports land — no page reload.

- imports-events.server.ts: in-process per-athlete publisher (EventEmitter
  keyed by athleteId, single-process; swappable for a shared transport later).
- imports-events.ts: shared constants + useRevalidateOnImportEvent client hook
  (opens EventSource via remix-utils useEventSource, revalidates on each event,
  closes on unmount, auto-reconnects via browser default).
- resources/imports-events.tsx: session-scoped text/event-stream resource route.
- createActivityImport publishes after a successful insert — the single choke
  point, so manual sync (#72), Backfill Window (#74), file upload, and future
  webhook ingest (#76) all push without per-call-site wiring.
- Imports surface subscribes via the hook; multi-athlete isolation by construction.
- CONTEXT.md: add the "Live Imports Stream" glossary entry.

Tests: publish/subscribe + isolation, emit-on-create, no-emit on duplicate
insert, and the client hook triggering the revalidator on event arrival.