### PR TITLE
fix: unbreak prod server boot — drop TS parameter property unsupported by Node type-stripping

### DIFF
--- a/app/integrations/strava/oauth.server.ts
+++ b/app/integrations/strava/oauth.server.ts
@@ -22,12 +22,12 @@ export function isStravaOAuthConfigured() {
 
 /** Thrown when exchanging the authorization code with Strava fails. */
 export class StravaTokenExchangeError extends Error {
-	constructor(
-		message: string,
-		readonly status?: number,
-	) {
+	readonly status?: number
+
+	constructor(message: string, status?: number) {
 		super(message)
 		this.name = 'StravaTokenExchangeError'
+		this.status = status
 	}
 }
 


### PR DESCRIPTION
The production server runs the app's TypeScript source directly via Node's
native type-stripping (strip-only mode), which does not support TypeScript
parameter properties. The `readonly status?: number` parameter property in
StravaTokenExchangeError's constructor threw

  SyntaxError: TypeScript parameter property is not supported in strip-only mode

at startup (the job worker's import graph pulls in oauth.server.ts). That
uncaughtException tripped closeWithGrace, server.close() hung on keep-alive
connections, and the process was force-killed after 10s — so every Playwright
test failed with ERR_CONNECTION_REFUSED while main's CI went red.

tsc, vitest, and the vite build all do full TS transforms, so they stayed
green and masked the runtime-only break. Declare the field explicitly and
assign it in the constructor body instead.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>