### PR TITLE
Add Strava webhook ingest for real-time activity sync (#76)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ GITHUB_REDIRECT_URI="https://example.com/auth/github/callback"
 STRAVA_CLIENT_ID="MOCK_STRAVA_CLIENT_ID"
 STRAVA_CLIENT_SECRET="MOCK_STRAVA_CLIENT_SECRET"
 STRAVA_REDIRECT_URI="https://example.com/integrations/strava/callback"
+# Webhook ingest (#76, ADR 0013). Signing secret verifies the
+# `X-Strava-Signature` HMAC; verify token is echoed at subscription setup.
+STRAVA_WEBHOOK_SIGNING_SECRET="MOCK_STRAVA_WEBHOOK_SIGNING_SECRET"
+STRAVA_WEBHOOK_VERIFY_TOKEN="MOCK_STRAVA_WEBHOOK_VERIFY_TOKEN"
 
 # set this to false to prevent search engines from indexing the website
 # default to allow indexing for seo safety

--- a/app/integrations/strava/ingest.server.ts
+++ b/app/integrations/strava/ingest.server.ts
@@ -3,7 +3,11 @@ import { type ActivityImportInput } from '#app/utils/activity-import.server.ts'
 import { stravaApiGet } from './client.server.ts'
 import { stravaTypeToDiscipline } from './discipline-map.ts'
 import { createRateLimiter, STRAVA_RATE_LIMIT } from './rate-limit.ts'
-import { StravaActivitiesSchema, type StravaActivity } from './types.ts'
+import {
+	StravaActivitiesSchema,
+	StravaActivitySchema,
+	type StravaActivity,
+} from './types.ts'
 
 /**
  * Shared Strava ingest primitives used by both manual sync (#72) and the
@@ -86,4 +90,20 @@ export async function fetchStravaActivitiesAfter(
 		if (activities.length < PER_PAGE) break
 	}
 	return all
+}
+
+/**
+ * Fetch a single Strava activity by its external id. Used by the webhook fetch
+ * worker (#76), which receives only `{ object_id }` and must pull the body out
+ * of band. Shares the process-wide rate limiter so a burst of webhook events
+ * stays within the per-app budget.
+ */
+export async function fetchStravaActivityById(
+	connection: ConnectionRef,
+	externalId: string,
+): Promise<StravaActivity> {
+	await stravaRateLimiter.acquire()
+	return StravaActivitySchema.parse(
+		await stravaApiGet(connection, `/activities/${externalId}`),
+	)
 }

--- a/app/integrations/strava/webhook-runbook.md
+++ b/app/integrations/strava/webhook-runbook.md
@@ -1,0 +1,67 @@
+# Strava webhook runbook
+
+How the Strava webhook ingest (#76, ADR 0013) is wired and how an operator
+registers it per environment.
+
+## What it does
+
+Strava POSTs a tiny event (`{ object_type, object_id, aspect_type, owner_id }`)
+to `/webhook/strava` whenever an athlete's activity is created, updated, or
+deleted, or when the athlete deauthorizes the app. The route verifies the
+`X-Strava-Signature` HMAC, enqueues a `strava-webhook` job, and returns `200`
+within Strava's 2-second budget. The queue worker (ADR 0013) does the
+out-of-band work:
+
+- **create** — fetch the activity, file an `ActivityImport`, auto-match it to a
+  planned same-day session (manual-sync behaviour). The single insert choke
+  point pushes the live Imports SSE event (#75).
+- **update** — refresh a non-promoted import's snapshot from Strava. Promoted
+  **Recordings** are immutable to source-side edits (ADR 0012); the fetch is
+  skipped entirely for them.
+- **delete** — remove a non-promoted import. Promoted **Recordings** survive
+  (ADR 0012).
+- **deauthorize** (`object_type: athlete`, `updates.authorized: 'false'`) —
+  move the `AccountConnection` to `revoked`. Non-promoted imports are **kept**
+  so the athlete can re-authorize without losing the inbox.
+
+All flows are idempotent: duplicate `create` events hit the unique
+`(provider, externalId)` guard, and refresh/delete/revoke are effect-idempotent.
+
+## Environment variables
+
+| Var                             | Purpose                                              |
+| ------------------------------- | ---------------------------------------------------- |
+| `STRAVA_CLIENT_ID`              | Strava app client id (subscription registration).    |
+| `STRAVA_CLIENT_SECRET`          | Strava app client secret.                            |
+| `STRAVA_WEBHOOK_SIGNING_SECRET` | Verifies the `X-Strava-Signature` HMAC on events.    |
+| `STRAVA_WEBHOOK_VERIFY_TOKEN`   | Echoed during the GET subscription verification.     |
+| `STRAVA_WEBHOOK_CALLBACK_URL`   | Optional. Public URL of `/webhook/strava`.           |
+
+When `STRAVA_WEBHOOK_SIGNING_SECRET` is unset, the route reports the integration
+as unconfigured (`503`) and the system relies on the dev fallback below.
+
+## Registering the subscription (once per environment)
+
+After deploying a publicly reachable `/webhook/strava`:
+
+```sh
+npx tsx scripts/register-strava-webhook.ts https://your-host/webhook/strava
+```
+
+The callback URL can also come from `STRAVA_WEBHOOK_CALLBACK_URL`, or is derived
+from the origin of `STRAVA_REDIRECT_URI`. Strava immediately GETs the callback
+with `hub.challenge` + `hub.verify_token`; the route echoes the challenge when
+the token matches. The script is **idempotent** — Strava allows only one
+subscription per app, so a re-run reports the existing subscription instead of
+creating a duplicate.
+
+## Local development fallback
+
+`localhost` cannot receive Strava webhooks. In development, leave the webhook
+unconfigured and rely on:
+
+- **Manual "Sync now"** (#72) from the Imports surface, and
+- the **daily reconciliation poll** (#77),
+
+which feed the same queue and pipeline. Use ngrok (or similar) only if you want
+to exercise the webhook path end-to-end locally; it is not required.

--- a/app/integrations/strava/webhook.server.test.ts
+++ b/app/integrations/strava/webhook.server.test.ts
@@ -383,6 +383,85 @@ test('registering a webhook subscription is idempotent when one already exists',
 	expect(posted).toBe(false)
 })
 
+test('a create event whose grant was revoked completes as a no-op', async () => {
+	const user = await setupConnectedAthlete()
+	// Force a token refresh on fetch, then make the refresh fail permanently (4xx)
+	// so the client marks the connection revoked and throws.
+	await prisma.accountConnection.updateMany({
+		where: { athleteId: user.id, provider: 'strava' },
+		data: { expiresAt: new Date(Date.now() - 60 * 1000) },
+	})
+	server.use(
+		http.post('https://www.strava.com/oauth/token', () =>
+			HttpResponse.json({ message: 'Bad Request' }, { status: 400 }),
+		),
+	)
+
+	const job = await enqueueJob({
+		kind: STRAVA_WEBHOOK_JOB_KIND,
+		payload: {
+			objectType: 'activity',
+			objectId: '5009',
+			aspectType: 'create',
+			ownerId: EXTERNAL_ATHLETE_ID,
+		} satisfies StravaWebhookJobPayload,
+	})
+
+	const result = await processNextJob(jobHandlers)
+
+	expect(result).toBe('processed')
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job.id } })
+	expect(row.status).toBe('completed')
+	const imports = await prisma.activityImport.count({
+		where: { athleteId: user.id, externalId: '5009' },
+	})
+	expect(imports).toBe(0)
+	const connection = await prisma.accountConnection.findFirstOrThrow({
+		where: { athleteId: user.id, provider: 'strava' },
+		select: { status: true },
+	})
+	expect(connection.status).toBe('revoked')
+})
+
+test('registering a webhook subscription sends form-encoded parameters', async () => {
+	let contentType: string | null = null
+	let bodyText = ''
+	server.use(
+		http.get('https://www.strava.com/api/v3/push_subscriptions', () =>
+			HttpResponse.json([]),
+		),
+		http.post(
+			'https://www.strava.com/api/v3/push_subscriptions',
+			async ({ request }) => {
+				contentType = request.headers.get('content-type')
+				bodyText = await request.text()
+				return HttpResponse.json({ id: 42 })
+			},
+		),
+	)
+
+	await registerStravaWebhookSubscription(SUBSCRIPTION_ARGS)
+
+	expect(contentType).toMatch(/application\/x-www-form-urlencoded/)
+	const params = new URLSearchParams(bodyText)
+	expect(params.get('callback_url')).toBe(SUBSCRIPTION_ARGS.callbackUrl)
+	expect(params.get('verify_token')).toBe(SUBSCRIPTION_ARGS.verifyToken)
+})
+
+test('registering fails when an existing subscription points at a different callback', async () => {
+	server.use(
+		http.get('https://www.strava.com/api/v3/push_subscriptions', () =>
+			HttpResponse.json([
+				{ id: 7, callback_url: 'https://old-host.example.com/webhook/strava' },
+			]),
+		),
+	)
+
+	await expect(
+		registerStravaWebhookSubscription(SUBSCRIPTION_ARGS),
+	).rejects.toThrow(/callback/i)
+})
+
 test('a duplicate create event does not create a second import', async () => {
 	const user = await setupConnectedAthlete()
 	mockActivity('5002')

--- a/app/integrations/strava/webhook.server.test.ts
+++ b/app/integrations/strava/webhook.server.test.ts
@@ -1,0 +1,404 @@
+import { http, HttpResponse } from 'msw'
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { jobHandlers } from '#app/utils/jobs/handlers.server.ts'
+import { enqueueJob, processNextJob } from '#app/utils/jobs/queue.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { server } from '#tests/mocks/index.ts'
+import {
+	registerStravaWebhookSubscription,
+	STRAVA_WEBHOOK_JOB_KIND,
+	type StravaWebhookJobPayload,
+} from './webhook.server.ts'
+
+const EXTERNAL_ATHLETE_ID = '12345678'
+
+async function setupConnectedAthlete() {
+	const user = await prisma.user.create({
+		select: { id: true },
+		data: {
+			...createUser(),
+			athleteProfile: { create: { timezone: 'UTC' } },
+		},
+	})
+	await prisma.accountConnection.create({
+		data: {
+			athleteId: user.id,
+			provider: 'strava',
+			externalAthleteId: EXTERNAL_ATHLETE_ID,
+			accessToken: 'initial_access',
+			refreshToken: 'initial_refresh',
+			expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+			status: 'active',
+			connectedAt: new Date('2026-05-28T00:00:00.000Z'),
+		},
+	})
+	return user
+}
+
+function mockActivity(id: string, overrides: Record<string, unknown> = {}) {
+	server.use(
+		http.get(`https://www.strava.com/api/v3/activities/${id}`, () =>
+			HttpResponse.json({
+				id,
+				name: 'Webhook Run',
+				sport_type: 'Run',
+				type: 'Run',
+				distance: 10000,
+				moving_time: 3000,
+				elapsed_time: 3100,
+				start_date: '2026-05-25T06:00:00Z',
+				average_heartrate: 150,
+				...overrides,
+			}),
+		),
+	)
+}
+
+async function enqueueAndRun(payload: StravaWebhookJobPayload) {
+	await enqueueJob({ kind: STRAVA_WEBHOOK_JOB_KIND, payload })
+	return processNextJob(jobHandlers)
+}
+
+test('a create event fetches the activity and files an ActivityImport', async () => {
+	const user = await setupConnectedAthlete()
+	mockActivity('5001')
+
+	const result = await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '5001',
+		aspectType: 'create',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	expect(result).toBe('processed')
+	const imp = await prisma.activityImport.findUnique({
+		where: {
+			externalProvider_externalId: {
+				externalProvider: 'strava',
+				externalId: '5001',
+			},
+		},
+	})
+	expect(imp).not.toBeNull()
+	expect(imp!.athleteId).toBe(user.id)
+	expect(imp!.discipline).toBe('run')
+})
+
+test('a create event auto-matches the import to a planned same-day session', async () => {
+	const user = await setupConnectedAthlete()
+	// Activity lands on 2026-05-25 (run); a planned run session that day exists.
+	mockActivity('5003')
+	const workout = await prisma.workout.create({
+		select: { id: true },
+		data: {
+			title: 'Planned Run',
+			discipline: 'run',
+			intent: 'endurance',
+			ownerId: user.id,
+		},
+	})
+	const session = await prisma.workoutSession.create({
+		select: { id: true },
+		data: {
+			userId: user.id,
+			workoutId: workout.id,
+			scheduledAt: new Date('2026-05-25T09:00:00Z'),
+			status: 'scheduled',
+		},
+	})
+
+	await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '5003',
+		aspectType: 'create',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	const imp = await prisma.activityImport.findUnique({
+		where: {
+			externalProvider_externalId: {
+				externalProvider: 'strava',
+				externalId: '5003',
+			},
+		},
+		select: { id: true, promotedSessionId: true },
+	})
+	expect(imp!.promotedSessionId).toBe(session.id)
+	const linked = await prisma.workoutSession.findUnique({
+		where: { id: session.id },
+		select: { recordingId: true },
+	})
+	expect(linked!.recordingId).toBe(imp!.id)
+})
+
+test('an update event refreshes a non-promoted import in place', async () => {
+	const user = await setupConnectedAthlete()
+	const original = await prisma.activityImport.create({
+		select: { id: true },
+		data: {
+			athleteId: user.id,
+			externalProvider: 'strava',
+			externalId: '6001',
+			startedAt: new Date('2026-05-25T06:00:00Z'),
+			endedAt: new Date('2026-05-25T06:50:00Z'),
+			durationSec: 3000,
+			distanceM: 10000,
+			discipline: 'run',
+			rawJson: '{}',
+		},
+	})
+	// Strava now reports a corrected distance for the same activity.
+	mockActivity('6001', { distance: 12345, moving_time: 3300 })
+
+	await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '6001',
+		aspectType: 'update',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	const refreshed = await prisma.activityImport.findUnique({
+		where: { id: original.id },
+		select: { distanceM: true, durationSec: true },
+	})
+	expect(refreshed!.distanceM).toBe(12345)
+	expect(refreshed!.durationSec).toBe(3300)
+})
+
+test('an update event leaves a promoted Recording unchanged', async () => {
+	const user = await setupConnectedAthlete()
+	const session = await prisma.workoutSession.create({
+		select: { id: true },
+		data: {
+			userId: user.id,
+			workoutId: null,
+			scheduledAt: new Date('2026-05-25T06:00:00Z'),
+			status: 'completed',
+		},
+	})
+	const promoted = await prisma.activityImport.create({
+		select: { id: true },
+		data: {
+			athleteId: user.id,
+			externalProvider: 'strava',
+			externalId: '6002',
+			startedAt: new Date('2026-05-25T06:00:00Z'),
+			endedAt: new Date('2026-05-25T06:50:00Z'),
+			durationSec: 3000,
+			distanceM: 10000,
+			discipline: 'run',
+			rawJson: '{}',
+			promotedSessionId: session.id,
+		},
+	})
+	// Strava reports a different distance, but a promoted Recording is immutable.
+	mockActivity('6002', { distance: 99999, moving_time: 9999 })
+
+	await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '6002',
+		aspectType: 'update',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	const after = await prisma.activityImport.findUnique({
+		where: { id: promoted.id },
+		select: { distanceM: true, durationSec: true },
+	})
+	expect(after!.distanceM).toBe(10000)
+	expect(after!.durationSec).toBe(3000)
+})
+
+test('a delete event removes a non-promoted import', async () => {
+	const user = await setupConnectedAthlete()
+	await prisma.activityImport.create({
+		data: {
+			athleteId: user.id,
+			externalProvider: 'strava',
+			externalId: '7001',
+			startedAt: new Date('2026-05-25T06:00:00Z'),
+			endedAt: new Date('2026-05-25T06:50:00Z'),
+			durationSec: 3000,
+			discipline: 'run',
+			rawJson: '{}',
+		},
+	})
+
+	await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '7001',
+		aspectType: 'delete',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	const gone = await prisma.activityImport.findUnique({
+		where: {
+			externalProvider_externalId: {
+				externalProvider: 'strava',
+				externalId: '7001',
+			},
+		},
+	})
+	expect(gone).toBeNull()
+})
+
+test('a delete event leaves a promoted Recording intact', async () => {
+	const user = await setupConnectedAthlete()
+	const session = await prisma.workoutSession.create({
+		select: { id: true },
+		data: {
+			userId: user.id,
+			workoutId: null,
+			scheduledAt: new Date('2026-05-25T06:00:00Z'),
+			status: 'completed',
+		},
+	})
+	const promoted = await prisma.activityImport.create({
+		select: { id: true },
+		data: {
+			athleteId: user.id,
+			externalProvider: 'strava',
+			externalId: '7002',
+			startedAt: new Date('2026-05-25T06:00:00Z'),
+			endedAt: new Date('2026-05-25T06:50:00Z'),
+			durationSec: 3000,
+			discipline: 'run',
+			rawJson: '{}',
+			promotedSessionId: session.id,
+		},
+	})
+
+	await enqueueAndRun({
+		objectType: 'activity',
+		objectId: '7002',
+		aspectType: 'delete',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	})
+
+	const survivor = await prisma.activityImport.findUnique({
+		where: { id: promoted.id },
+	})
+	expect(survivor).not.toBeNull()
+})
+
+test('a deauthorize event revokes the connection but keeps non-promoted imports', async () => {
+	const user = await setupConnectedAthlete()
+	await prisma.activityImport.create({
+		data: {
+			athleteId: user.id,
+			externalProvider: 'strava',
+			externalId: '8001',
+			startedAt: new Date('2026-05-25T06:00:00Z'),
+			endedAt: new Date('2026-05-25T06:50:00Z'),
+			durationSec: 3000,
+			discipline: 'run',
+			rawJson: '{}',
+		},
+	})
+
+	await enqueueAndRun({
+		objectType: 'athlete',
+		objectId: EXTERNAL_ATHLETE_ID,
+		aspectType: 'update',
+		ownerId: EXTERNAL_ATHLETE_ID,
+		updates: { authorized: 'false' },
+	})
+
+	const connection = await prisma.accountConnection.findFirstOrThrow({
+		where: { athleteId: user.id, provider: 'strava' },
+		select: { status: true },
+	})
+	expect(connection.status).toBe('revoked')
+	const stillThere = await prisma.activityImport.count({
+		where: { athleteId: user.id, externalId: '8001' },
+	})
+	expect(stillThere).toBe(1)
+})
+
+test('an event for an unknown owner is a no-op that completes cleanly', async () => {
+	const job = await enqueueJob({
+		kind: STRAVA_WEBHOOK_JOB_KIND,
+		payload: {
+			objectType: 'activity',
+			objectId: '9001',
+			aspectType: 'create',
+			ownerId: 'nobody-here',
+		} satisfies StravaWebhookJobPayload,
+	})
+
+	const result = await processNextJob(jobHandlers)
+
+	expect(result).toBe('processed')
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job.id } })
+	expect(row.status).toBe('completed')
+	const imports = await prisma.activityImport.count({
+		where: { externalId: '9001' },
+	})
+	expect(imports).toBe(0)
+})
+
+const SUBSCRIPTION_ARGS = {
+	callbackUrl: 'https://app.example.com/webhook/strava',
+	clientId: 'client-1',
+	clientSecret: 'secret-1',
+	verifyToken: 'verify-1',
+}
+
+test('registering a webhook subscription creates one when none exists', async () => {
+	let posted = false
+	server.use(
+		http.get('https://www.strava.com/api/v3/push_subscriptions', () =>
+			HttpResponse.json([]),
+		),
+		http.post('https://www.strava.com/api/v3/push_subscriptions', () => {
+			posted = true
+			return HttpResponse.json({ id: 42 })
+		}),
+	)
+
+	const result = await registerStravaWebhookSubscription(SUBSCRIPTION_ARGS)
+
+	expect(result).toEqual({ id: 42, created: true })
+	expect(posted).toBe(true)
+})
+
+test('registering a webhook subscription is idempotent when one already exists', async () => {
+	let posted = false
+	server.use(
+		http.get('https://www.strava.com/api/v3/push_subscriptions', () =>
+			HttpResponse.json([
+				{ id: 7, callback_url: SUBSCRIPTION_ARGS.callbackUrl },
+			]),
+		),
+		http.post('https://www.strava.com/api/v3/push_subscriptions', () => {
+			posted = true
+			return HttpResponse.json({ id: 999 })
+		}),
+	)
+
+	const result = await registerStravaWebhookSubscription(SUBSCRIPTION_ARGS)
+
+	expect(result).toEqual({ id: 7, created: false })
+	expect(posted).toBe(false)
+})
+
+test('a duplicate create event does not create a second import', async () => {
+	const user = await setupConnectedAthlete()
+	mockActivity('5002')
+
+	const createPayload: StravaWebhookJobPayload = {
+		objectType: 'activity',
+		objectId: '5002',
+		aspectType: 'create',
+		ownerId: EXTERNAL_ATHLETE_ID,
+	}
+	await enqueueAndRun(createPayload)
+	const second = await enqueueAndRun(createPayload)
+
+	expect(second).toBe('processed')
+	const imports = await prisma.activityImport.count({
+		where: { athleteId: user.id, externalId: '5002' },
+	})
+	expect(imports).toBe(1)
+})

--- a/app/integrations/strava/webhook.server.ts
+++ b/app/integrations/strava/webhook.server.ts
@@ -1,0 +1,272 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import {
+	autoMatchImport,
+	createActivityImport,
+	deleteActivityImportIfUnpromoted,
+	updateActivityImportSnapshot,
+} from '#app/utils/activity-import.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import {
+	fetchStravaActivityById,
+	mapActivityToImportInput,
+} from './ingest.server.ts'
+import { STRAVA_API_BASE, STRAVA_PROVIDER } from './types.ts'
+
+/**
+ * Strava webhook ingest (#76, ADR 0013). The public route verifies the
+ * `X-Strava-Signature` HMAC and enqueues a job; the queue worker resolves the
+ * owning athlete and performs the out-of-band work (fetch + create / refresh /
+ * delete / revoke). Provider-specific concerns stay in this folder (ADR 0014).
+ */
+
+/** The `kind` registered against the job queue for webhook events. */
+export const STRAVA_WEBHOOK_JOB_KIND = 'strava-webhook'
+
+/**
+ * Verify the `X-Strava-Signature` header: an HMAC-SHA256 hex digest of the raw
+ * request body keyed with the webhook signing secret. Constant-time compared so
+ * a mismatching or absent signature is rejected without leaking timing.
+ */
+export function verifyStravaSignature(
+	rawBody: string,
+	signature: string | null | undefined,
+	secret: string,
+): boolean {
+	if (!signature) return false
+	const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+	const expectedBuf = Buffer.from(expected, 'hex')
+	const actualBuf = Buffer.from(signature.replace(/^sha256=/, ''), 'hex')
+	if (expectedBuf.length !== actualBuf.length) return false
+	return timingSafeEqual(expectedBuf, actualBuf)
+}
+
+/**
+ * A Strava webhook event. `object_id` and `owner_id` are coerced to strings to
+ * line up with how `ActivityImport.externalId` and
+ * `AccountConnection.externalAthleteId` are stored. `updates` carries the
+ * deauthorize flag (`{ authorized: 'false' }`) and assorted field edits.
+ */
+export const StravaWebhookEventSchema = z.object({
+	object_type: z.enum(['activity', 'athlete']),
+	object_id: z.union([z.number(), z.string()]).transform((id) => String(id)),
+	aspect_type: z.enum(['create', 'update', 'delete']),
+	owner_id: z.union([z.number(), z.string()]).transform((id) => String(id)),
+	subscription_id: z.union([z.number(), z.string()]).optional(),
+	event_time: z.number().optional(),
+	updates: z.record(z.string(), z.string()).optional(),
+})
+export type StravaWebhookEvent = z.infer<typeof StravaWebhookEventSchema>
+
+/** The opaque job payload enqueued for each accepted event. */
+export type StravaWebhookJobPayload = {
+	objectType: StravaWebhookEvent['object_type']
+	objectId: string
+	aspectType: StravaWebhookEvent['aspect_type']
+	ownerId: string
+	updates?: Record<string, string>
+}
+
+/** Project a parsed event onto the queue payload the worker consumes. */
+export function toWebhookJobPayload(
+	event: StravaWebhookEvent,
+): StravaWebhookJobPayload {
+	return {
+		objectType: event.object_type,
+		objectId: event.object_id,
+		aspectType: event.aspect_type,
+		ownerId: event.owner_id,
+		...(event.updates ? { updates: event.updates } : {}),
+	}
+}
+
+const StravaWebhookJobPayloadSchema = z.object({
+	objectType: z.enum(['activity', 'athlete']),
+	objectId: z.string(),
+	aspectType: z.enum(['create', 'update', 'delete']),
+	ownerId: z.string(),
+	updates: z.record(z.string(), z.string()).optional(),
+})
+
+/** Parse a stored job payload back into a typed webhook payload. */
+export function parseWebhookJobPayload(
+	payload: Record<string, unknown>,
+): StravaWebhookJobPayload {
+	return StravaWebhookJobPayloadSchema.parse(payload)
+}
+
+/**
+ * Process one webhook event out of band (the queue worker's job, #76). Resolves
+ * the owning Account Connection from the Strava `owner_id` and dispatches by
+ * `aspect_type`. Unknown owners and not-yet-handled aspects are deliberate
+ * no-ops — only genuine fetch/DB errors throw so the queue retries them.
+ */
+export async function processStravaWebhookEvent(
+	payload: StravaWebhookJobPayload,
+): Promise<void> {
+	const connection = await prisma.accountConnection.findFirst({
+		where: {
+			provider: STRAVA_PROVIDER,
+			externalAthleteId: payload.ownerId,
+		},
+	})
+	// Event for an athlete we don't have a connection for: nothing to do.
+	if (!connection) return
+
+	if (payload.objectType === 'athlete') {
+		// Deauthorization at the source: move to `revoked` but keep non-promoted
+		// imports so the athlete can re-authorize without losing the inbox (ADR
+		// 0012). Only explicit disconnect cleans those up.
+		if (
+			payload.aspectType === 'update' &&
+			payload.updates?.authorized === 'false'
+		) {
+			await prisma.accountConnection.update({
+				where: { id: connection.id },
+				data: { status: 'revoked' },
+			})
+		}
+		return
+	}
+
+	if (payload.objectType === 'activity') {
+		// A revoked grant can't be fetched against; skip until re-authorized.
+		if (connection.status === 'revoked') return
+		if (payload.aspectType === 'create') {
+			await ingestCreatedActivity(connection, payload.objectId)
+		} else if (payload.aspectType === 'update') {
+			await refreshUpdatedActivity(connection, payload.objectId)
+		} else if (payload.aspectType === 'delete') {
+			// Promoted Recordings survive (ADR 0012); only the inbox copy is removed.
+			await deleteActivityImportIfUnpromoted(STRAVA_PROVIDER, payload.objectId)
+		}
+	}
+}
+
+/**
+ * Refresh a non-promoted import from a source-side `update`. Promoted Recordings
+ * are immutable (ADR 0012); when the local import is missing or already
+ * promoted there is nothing to refresh and we skip the Strava fetch to spare the
+ * rate budget.
+ */
+async function refreshUpdatedActivity(
+	connection: StravaConnectionRef,
+	externalId: string,
+): Promise<void> {
+	const existing = await prisma.activityImport.findUnique({
+		where: {
+			externalProvider_externalId: {
+				externalProvider: STRAVA_PROVIDER,
+				externalId,
+			},
+		},
+		select: { promotedSessionId: true },
+	})
+	if (!existing || existing.promotedSessionId != null) return
+
+	const activity = await fetchStravaActivityById(connection, externalId)
+	await updateActivityImportSnapshot(mapActivityToImportInput(activity))
+}
+
+/**
+ * Fetch a newly-created Strava activity and file it as an `ActivityImport`,
+ * then auto-match it to an existing planned session (the manual-sync behaviour,
+ * not backfill's auto-create). Idempotent: a duplicate event hits the unique
+ * `(provider, externalId)` guard and is skipped.
+ */
+type StravaConnectionRef = {
+	id: string
+	accessToken: string
+	refreshToken: string
+	expiresAt: Date
+	athleteId: string
+}
+
+async function ingestCreatedActivity(
+	connection: StravaConnectionRef,
+	externalId: string,
+): Promise<void> {
+	const activity = await fetchStravaActivityById(connection, externalId)
+	const input = mapActivityToImportInput(activity)
+
+	let importId: string
+	try {
+		importId = (await createActivityImport(connection.athleteId, input)).id
+	} catch (err) {
+		if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
+			return
+		}
+		throw err
+	}
+
+	// 'other' is import-only (ADR 0015): excluded from auto-match.
+	if (input.discipline === 'other') return
+
+	const timezone =
+		(
+			await prisma.athleteProfile.findUnique({
+				where: { userId: connection.athleteId },
+				select: { timezone: true },
+			})
+		)?.timezone ?? 'UTC'
+	await autoMatchImport(connection.athleteId, importId, timezone)
+}
+
+const StravaSubscriptionSchema = z.object({
+	id: z.number(),
+	callback_url: z.string().optional(),
+})
+
+/**
+ * Register (or confirm) the app-wide Strava push subscription (#76). Strava
+ * permits exactly one subscription per app, so this first lists the existing
+ * subscriptions and returns the current one untouched when present — making
+ * re-runs of `scripts/register-strava-webhook.ts` idempotent. Otherwise it
+ * creates the subscription; Strava then GETs the callback to verify the token.
+ */
+export async function registerStravaWebhookSubscription({
+	callbackUrl,
+	clientId,
+	clientSecret,
+	verifyToken,
+}: {
+	callbackUrl: string
+	clientId: string
+	clientSecret: string
+	verifyToken: string
+}): Promise<{ id: number; created: boolean }> {
+	const listUrl = new URL(`${STRAVA_API_BASE}/push_subscriptions`)
+	listUrl.searchParams.set('client_id', clientId)
+	listUrl.searchParams.set('client_secret', clientSecret)
+
+	const listResponse = await fetch(listUrl)
+	if (!listResponse.ok) {
+		throw new Error(
+			`Strava push_subscriptions list failed (${listResponse.status})`,
+		)
+	}
+	const existing = z
+		.array(StravaSubscriptionSchema)
+		.parse(await listResponse.json())
+	if (existing.length > 0) {
+		return { id: existing[0]!.id, created: false }
+	}
+
+	const createResponse = await fetch(`${STRAVA_API_BASE}/push_subscriptions`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({
+			client_id: clientId,
+			client_secret: clientSecret,
+			callback_url: callbackUrl,
+			verify_token: verifyToken,
+		}),
+	})
+	if (!createResponse.ok) {
+		throw new Error(
+			`Strava push_subscriptions create failed (${createResponse.status})`,
+		)
+	}
+	const created = StravaSubscriptionSchema.parse(await createResponse.json())
+	return { id: created.id, created: true }
+}

--- a/app/integrations/strava/webhook.server.ts
+++ b/app/integrations/strava/webhook.server.ts
@@ -7,6 +7,7 @@ import {
 	updateActivityImportSnapshot,
 } from '#app/utils/activity-import.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { StravaConnectionRevokedError } from './client.server.ts'
 import {
 	fetchStravaActivityById,
 	mapActivityToImportInput,
@@ -132,13 +133,25 @@ export async function processStravaWebhookEvent(
 	if (payload.objectType === 'activity') {
 		// A revoked grant can't be fetched against; skip until re-authorized.
 		if (connection.status === 'revoked') return
-		if (payload.aspectType === 'create') {
-			await ingestCreatedActivity(connection, payload.objectId)
-		} else if (payload.aspectType === 'update') {
-			await refreshUpdatedActivity(connection, payload.objectId)
-		} else if (payload.aspectType === 'delete') {
-			// Promoted Recordings survive (ADR 0012); only the inbox copy is removed.
-			await deleteActivityImportIfUnpromoted(STRAVA_PROVIDER, payload.objectId)
+		try {
+			if (payload.aspectType === 'create') {
+				await ingestCreatedActivity(connection, payload.objectId)
+			} else if (payload.aspectType === 'update') {
+				await refreshUpdatedActivity(connection, payload.objectId)
+			} else if (payload.aspectType === 'delete') {
+				// Promoted Recordings survive (ADR 0012); only the inbox copy is removed.
+				await deleteActivityImportIfUnpromoted(
+					STRAVA_PROVIDER,
+					payload.objectId,
+				)
+			}
+		} catch (err) {
+			// A permanently revoked grant is a deliberate outcome, not a transient
+			// failure: the client has already marked the connection `revoked`, so
+			// complete the job as a no-op instead of retrying (matches manual sync
+			// and backfill). Genuine fetch/DB errors still throw and retry.
+			if (err instanceof StravaConnectionRevokedError) return
+			throw err
 		}
 	}
 }
@@ -249,18 +262,28 @@ export async function registerStravaWebhookSubscription({
 		.array(StravaSubscriptionSchema)
 		.parse(await listResponse.json())
 	if (existing.length > 0) {
-		return { id: existing[0]!.id, created: false }
+		const current = existing[0]!
+		// Strava allows only one subscription per app. If it already points at a
+		// different callback, fail loudly rather than silently leaving the
+		// environment wired to a stale host — the operator must recreate it.
+		if (current.callback_url && current.callback_url !== callbackUrl) {
+			throw new Error(
+				`A Strava webhook subscription (id ${current.id}) already exists for a different callback URL (${current.callback_url}). Delete it before registering ${callbackUrl}.`,
+			)
+		}
+		return { id: current.id, created: false }
 	}
 
+	// Strava's push-subscription create endpoint expects form-encoded parameters.
 	const createResponse = await fetch(`${STRAVA_API_BASE}/push_subscriptions`, {
 		method: 'POST',
-		headers: { 'content-type': 'application/json' },
-		body: JSON.stringify({
+		headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
 			client_id: clientId,
 			client_secret: clientSecret,
 			callback_url: callbackUrl,
 			verify_token: verifyToken,
-		}),
+		}).toString(),
 	})
 	if (!createResponse.ok) {
 		throw new Error(

--- a/app/routes/webhook.strava.test.ts
+++ b/app/routes/webhook.strava.test.ts
@@ -79,6 +79,24 @@ test('GET subscription verification is rejected when the verify token does not m
 	expect(response.status).toBe(403)
 })
 
+test('a validly-signed but unparseable body is acknowledged with 200 and enqueues nothing', async () => {
+	const rawBody = 'this is not json'
+	const request = new Request(new URL(ROUTE_PATH, BASE_URL).toString(), {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'x-strava-signature': sign(rawBody),
+		},
+		body: rawBody,
+	})
+
+	const response = await action({ request, ...ACTION_ARGS_BASE })
+
+	expect(response.status).toBe(200)
+	const jobs = await prisma.job.count({ where: { kind: 'strava-webhook' } })
+	expect(jobs).toBe(0)
+})
+
 test('an event with a bad signature is rejected with 403 and enqueues nothing', async () => {
 	const response = await action({
 		request: eventRequest(ACTIVITY_CREATE_EVENT, { signature: 'deadbeef' }),

--- a/app/routes/webhook.strava.test.ts
+++ b/app/routes/webhook.strava.test.ts
@@ -1,0 +1,109 @@
+import { createHmac } from 'node:crypto'
+import { type AppLoadContext } from 'react-router'
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { BASE_URL } from '#tests/utils.ts'
+import { action, loader } from './webhook.strava.tsx'
+
+const ROUTE_PATH = '/webhook/strava'
+const SIGNING_SECRET = process.env.STRAVA_WEBHOOK_SIGNING_SECRET!
+const VERIFY_TOKEN = process.env.STRAVA_WEBHOOK_VERIFY_TOKEN!
+
+function verificationRequest(params: Record<string, string>) {
+	const url = new URL(ROUTE_PATH, BASE_URL)
+	for (const [key, value] of Object.entries(params)) {
+		url.searchParams.set(key, value)
+	}
+	return new Request(url.toString(), { method: 'GET' })
+}
+const ACTION_ARGS_BASE = {
+	params: {},
+	context: {} as AppLoadContext,
+	unstable_pattern: ROUTE_PATH,
+}
+
+function sign(rawBody: string) {
+	return createHmac('sha256', SIGNING_SECRET).update(rawBody).digest('hex')
+}
+
+function eventRequest(
+	event: Record<string, unknown>,
+	{ signature }: { signature?: string } = {},
+) {
+	const rawBody = JSON.stringify(event)
+	return new Request(new URL(ROUTE_PATH, BASE_URL).toString(), {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			'x-strava-signature': signature ?? sign(rawBody),
+		},
+		body: rawBody,
+	})
+}
+
+const ACTIVITY_CREATE_EVENT = {
+	object_type: 'activity',
+	object_id: 1001,
+	aspect_type: 'create',
+	owner_id: 12345678,
+	subscription_id: 1,
+	event_time: 1700000000,
+}
+
+test('GET subscription verification echoes the challenge when the verify token matches', async () => {
+	const response = await loader({
+		request: verificationRequest({
+			'hub.mode': 'subscribe',
+			'hub.verify_token': VERIFY_TOKEN,
+			'hub.challenge': 'abc123challenge',
+		}),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response.status).toBe(200)
+	await expect(response.json()).resolves.toEqual({
+		'hub.challenge': 'abc123challenge',
+	})
+})
+
+test('GET subscription verification is rejected when the verify token does not match', async () => {
+	const response = await loader({
+		request: verificationRequest({
+			'hub.mode': 'subscribe',
+			'hub.verify_token': 'wrong-token',
+			'hub.challenge': 'abc123challenge',
+		}),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response.status).toBe(403)
+})
+
+test('an event with a bad signature is rejected with 403 and enqueues nothing', async () => {
+	const response = await action({
+		request: eventRequest(ACTIVITY_CREATE_EVENT, { signature: 'deadbeef' }),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response.status).toBe(403)
+	const jobs = await prisma.job.count({ where: { kind: 'strava-webhook' } })
+	expect(jobs).toBe(0)
+})
+
+test('a validly-signed event is accepted and enqueues a fetch job', async () => {
+	const response = await action({
+		request: eventRequest(ACTIVITY_CREATE_EVENT),
+		...ACTION_ARGS_BASE,
+	})
+
+	expect(response.status).toBe(200)
+	const jobs = await prisma.job.findMany({ where: { kind: 'strava-webhook' } })
+	expect(jobs).toHaveLength(1)
+	const payload = JSON.parse(jobs[0]!.payload) as Record<string, unknown>
+	expect(payload).toMatchObject({
+		objectType: 'activity',
+		objectId: '1001',
+		aspectType: 'create',
+		ownerId: '12345678',
+	})
+})

--- a/app/routes/webhook.strava.tsx
+++ b/app/routes/webhook.strava.tsx
@@ -1,0 +1,64 @@
+import {
+	STRAVA_WEBHOOK_JOB_KIND,
+	StravaWebhookEventSchema,
+	toWebhookJobPayload,
+	verifyStravaSignature,
+} from '#app/integrations/strava/webhook.server.ts'
+import { enqueueJob } from '#app/utils/jobs/queue.server.ts'
+import { type Route } from './+types/webhook.strava.ts'
+
+/**
+ * Public Strava webhook endpoint (#76, ADR 0013). The handler is a notification
+ * sink only: it verifies the `X-Strava-Signature` HMAC, enqueues a fetch job,
+ * and returns 200 well within Strava's 2-second budget. The activity body is
+ * fetched out of band by the queue worker.
+ */
+/**
+ * GET subscription verification, used only at subscription-registration time
+ * (ADR 0013). Strava echoes a challenge that we must return as JSON, but only
+ * when the `hub.verify_token` matches the configured token.
+ */
+export async function loader({ request }: Route.LoaderArgs) {
+	const url = new URL(request.url)
+	const mode = url.searchParams.get('hub.mode')
+	const verifyToken = url.searchParams.get('hub.verify_token')
+	const challenge = url.searchParams.get('hub.challenge')
+
+	const expectedToken = process.env.STRAVA_WEBHOOK_VERIFY_TOKEN
+	if (
+		mode === 'subscribe' &&
+		expectedToken &&
+		verifyToken === expectedToken &&
+		challenge
+	) {
+		return Response.json({ 'hub.challenge': challenge })
+	}
+	return new Response('Forbidden', { status: 403 })
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const secret = process.env.STRAVA_WEBHOOK_SIGNING_SECRET
+	if (!secret) {
+		// Webhooks are unconfigured (dev fallback is manual sync + reconciliation).
+		return new Response('Webhook not configured', { status: 503 })
+	}
+
+	const rawBody = await request.text()
+	const signature = request.headers.get('x-strava-signature')
+	if (!verifyStravaSignature(rawBody, signature, secret)) {
+		return new Response('Invalid signature', { status: 403 })
+	}
+
+	const parsed = StravaWebhookEventSchema.safeParse(JSON.parse(rawBody))
+	if (!parsed.success) {
+		// Acknowledge malformed events so Strava does not retry them forever.
+		return new Response('Ignored', { status: 200 })
+	}
+
+	await enqueueJob({
+		kind: STRAVA_WEBHOOK_JOB_KIND,
+		payload: toWebhookJobPayload(parsed.data),
+	})
+
+	return new Response('OK', { status: 200 })
+}

--- a/app/routes/webhook.strava.tsx
+++ b/app/routes/webhook.strava.tsx
@@ -8,12 +8,6 @@ import { enqueueJob } from '#app/utils/jobs/queue.server.ts'
 import { type Route } from './+types/webhook.strava.ts'
 
 /**
- * Public Strava webhook endpoint (#76, ADR 0013). The handler is a notification
- * sink only: it verifies the `X-Strava-Signature` HMAC, enqueues a fetch job,
- * and returns 200 well within Strava's 2-second budget. The activity body is
- * fetched out of band by the queue worker.
- */
-/**
  * GET subscription verification, used only at subscription-registration time
  * (ADR 0013). Strava echoes a challenge that we must return as JSON, but only
  * when the `hub.verify_token` matches the configured token.
@@ -36,6 +30,12 @@ export async function loader({ request }: Route.LoaderArgs) {
 	return new Response('Forbidden', { status: 403 })
 }
 
+/**
+ * Public Strava webhook endpoint (#76, ADR 0013). The handler is a notification
+ * sink only: it verifies the `X-Strava-Signature` HMAC, enqueues a fetch job,
+ * and returns 200 well within Strava's 2-second budget. The activity body is
+ * fetched out of band by the queue worker.
+ */
 export async function action({ request }: Route.ActionArgs) {
 	const secret = process.env.STRAVA_WEBHOOK_SIGNING_SECRET
 	if (!secret) {
@@ -49,9 +49,17 @@ export async function action({ request }: Route.ActionArgs) {
 		return new Response('Invalid signature', { status: 403 })
 	}
 
-	const parsed = StravaWebhookEventSchema.safeParse(JSON.parse(rawBody))
+	// Acknowledge unparseable or schema-invalid bodies with 200 so Strava does
+	// not retry payloads this endpoint will never be able to process.
+	let body: unknown
+	try {
+		body = JSON.parse(rawBody)
+	} catch {
+		return new Response('Ignored', { status: 200 })
+	}
+
+	const parsed = StravaWebhookEventSchema.safeParse(body)
 	if (!parsed.success) {
-		// Acknowledge malformed events so Strava does not retry them forever.
 		return new Response('Ignored', { status: 200 })
 	}
 

--- a/app/utils/activity-import.server.ts
+++ b/app/utils/activity-import.server.ts
@@ -76,6 +76,53 @@ export async function createActivityImport(
 	return created
 }
 
+/**
+ * Refresh a non-promoted import's snapshot in place from a fresh provider
+ * payload (source-side `update`, #76). Promoted Recordings are immutable to
+ * source-side changes (ADR 0012), so the update is guarded on
+ * `promotedSessionId IS NULL` and reports whether a row was actually touched.
+ */
+export async function updateActivityImportSnapshot(
+	input: ActivityImportInput,
+): Promise<{ updated: boolean }> {
+	const { count } = await prisma.activityImport.updateMany({
+		where: {
+			externalProvider: input.externalProvider,
+			externalId: input.externalId,
+			promotedSessionId: null,
+		},
+		data: {
+			startedAt: input.startedAt,
+			endedAt: input.endedAt,
+			durationSec: input.durationSec,
+			distanceM: input.distanceM ?? null,
+			discipline: input.discipline,
+			hrAvg: input.hrAvg ?? null,
+			powerAvg: input.powerAvg ?? null,
+			paceAvgSecPerKm: input.paceAvgSecPerKm ?? null,
+			polyline: input.polyline ?? null,
+			rawJson: input.rawJson,
+		},
+	})
+	return { updated: count > 0 }
+}
+
+/**
+ * Remove a non-promoted import on a source-side `delete` (#76). Promoted
+ * Recordings survive — the athlete's training history is immutable to
+ * source-side deletes (ADR 0012) — so the delete is guarded on
+ * `promotedSessionId IS NULL`.
+ */
+export async function deleteActivityImportIfUnpromoted(
+	externalProvider: string,
+	externalId: string,
+): Promise<{ deleted: boolean }> {
+	const { count } = await prisma.activityImport.deleteMany({
+		where: { externalProvider, externalId, promotedSessionId: null },
+	})
+	return { deleted: count > 0 }
+}
+
 export async function getInboxImports(athleteId: string) {
 	return prisma.activityImport.findMany({
 		where: { athleteId, promotedSessionId: null },

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -24,6 +24,13 @@ const schema = z.object({
 	STRAVA_CLIENT_ID: z.string().optional(),
 	STRAVA_CLIENT_SECRET: z.string().optional(),
 	STRAVA_REDIRECT_URI: z.string().optional(),
+	// Webhook ingest (#76, ADR 0013). The signing secret verifies the
+	// `X-Strava-Signature` HMAC on incoming events; the verify token is echoed
+	// during subscription registration. Optional: when unset, the webhook route
+	// reports the integration as unconfigured and the dev fallback is manual
+	// sync + reconciliation.
+	STRAVA_WEBHOOK_SIGNING_SECRET: z.string().optional(),
+	STRAVA_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
 
 	ALLOW_INDEXING: z.enum(['true', 'false']).optional(),
 

--- a/app/utils/jobs/handlers.server.ts
+++ b/app/utils/jobs/handlers.server.ts
@@ -1,4 +1,9 @@
 import { runStravaBackfill } from '#app/integrations/strava/backfill.server.ts'
+import {
+	parseWebhookJobPayload,
+	processStravaWebhookEvent,
+	STRAVA_WEBHOOK_JOB_KIND,
+} from '#app/integrations/strava/webhook.server.ts'
 import { type JobHandlers } from './queue.server.ts'
 
 /**
@@ -16,5 +21,10 @@ export const jobHandlers: JobHandlers = {
 		// Account Connection carries the truth and a fresh connect re-enqueues a
 		// backfill. Only genuine fetch/DB errors throw and trigger retry.
 		await runStravaBackfill(athleteId)
+	},
+	[STRAVA_WEBHOOK_JOB_KIND]: async (payload) => {
+		// A missing Account Connection or a revoked grant is a deliberate no-op
+		// inside the processor — only genuine fetch/DB errors throw and retry.
+		await processStravaWebhookEvent(parseWebhookJobPayload(payload))
 	},
 }

--- a/scripts/register-strava-webhook.ts
+++ b/scripts/register-strava-webhook.ts
@@ -1,0 +1,56 @@
+import 'dotenv/config'
+import { registerStravaWebhookSubscription } from '#app/integrations/strava/webhook.server.ts'
+
+/**
+ * One-shot operator CLI to register the app-wide Strava push subscription
+ * (#76, ADR 0013). Run once per environment after deploying a publicly
+ * reachable `/webhook/strava`. Idempotent: re-running reports the existing
+ * subscription rather than creating a duplicate (Strava allows only one per
+ * app).
+ *
+ *   npx tsx scripts/register-strava-webhook.ts <callback-url>
+ *
+ * The callback URL defaults to the origin of STRAVA_REDIRECT_URI + /webhook/strava.
+ * See app/integrations/strava/webhook-runbook.md for the full runbook.
+ */
+
+function resolveCallbackUrl(): string {
+	const fromArg = process.argv[2]
+	if (fromArg) return fromArg
+	const fromEnv = process.env.STRAVA_WEBHOOK_CALLBACK_URL
+	if (fromEnv) return fromEnv
+	const redirect = process.env.STRAVA_REDIRECT_URI
+	if (redirect) return new URL('/webhook/strava', redirect).toString()
+	throw new Error(
+		'No callback URL: pass one as the first argument, set STRAVA_WEBHOOK_CALLBACK_URL, or set STRAVA_REDIRECT_URI.',
+	)
+}
+
+function required(name: string): string {
+	const value = process.env[name]
+	if (!value) throw new Error(`Missing required env var ${name}`)
+	return value
+}
+
+async function main() {
+	const result = await registerStravaWebhookSubscription({
+		callbackUrl: resolveCallbackUrl(),
+		clientId: required('STRAVA_CLIENT_ID'),
+		clientSecret: required('STRAVA_CLIENT_SECRET'),
+		verifyToken: required('STRAVA_WEBHOOK_VERIFY_TOKEN'),
+	})
+
+	if (result.created) {
+		console.log(`✅ Created Strava webhook subscription (id ${result.id}).`)
+	} else {
+		console.log(
+			`ℹ️  Strava webhook subscription already exists (id ${result.id}); nothing to do.`,
+		)
+	}
+}
+
+main().catch((error: unknown) => {
+	console.error('❌ Failed to register Strava webhook subscription:')
+	console.error(error instanceof Error ? error.message : error)
+	process.exit(1)
+})


### PR DESCRIPTION
## Summary

Implements real-time activity synchronization from Strava via push webhooks (#76, ADR 0013). When athletes create, update, or delete activities in Strava, or deauthorize the app, Strava POSTs a lightweight event to `/webhook/strava`. The route verifies the HMAC signature and enqueues a job; the queue worker fetches the activity details and performs the appropriate action (create import, refresh snapshot, delete import, or revoke connection).

### Key features:
- **Webhook verification**: HMAC-SHA256 signature validation on incoming events
- **Activity create**: Fetches activity details, files an `ActivityImport`, and auto-matches to same-day planned sessions (manual-sync behavior)
- **Activity update**: Refreshes non-promoted imports in place; promoted Recordings are immutable (ADR 0012)
- **Activity delete**: Removes non-promoted imports; promoted Recordings survive
- **Deauthorization**: Moves connection to `revoked` status while preserving non-promoted imports for re-authorization
- **Idempotency**: Duplicate events are safely handled via unique constraints and effect-idempotent operations
- **Subscription registration**: CLI script to register the app-wide Strava push subscription (idempotent)

### Architecture:
- Provider-specific logic stays in `app/integrations/strava/` (ADR 0014)
- Public route (`app/routes/webhook.strava.tsx`) handles verification and queueing only
- Worker (`webhook.server.ts`) handles out-of-band fetching and database operations
- Reuses existing ingest primitives (`fetchStravaActivityById`, `mapActivityToImportInput`)
- Integrates with activity import system for auto-matching and promotion

## Test Plan

Added comprehensive test suites:
- **`webhook.server.test.ts`** (404 lines): Tests all webhook event types (create, update, delete, deauthorize), idempotency, promoted Recording immutability, subscription registration, and edge cases
- **`webhook.strava.test.ts`** (109 lines): Tests route-level verification (GET subscription challenge, POST signature validation), job enqueueing

All tests pass with the new implementation.

## Checklist

- [x] Tests updated (added 513 lines of test coverage)
- [x] Docs updated (added webhook-runbook.md with operator guide)
- [x] Environment variables documented (.env.example, env.server.ts)

https://claude.ai/code/session_01RHpG1af3dhZWVaLAa6Cmtr