### PR TITLE
Add Strava reconciliation poll (#77)

### DIFF
--- a/app/integrations/strava/ingest.server.ts
+++ b/app/integrations/strava/ingest.server.ts
@@ -1,5 +1,9 @@
 import { type AccountConnection } from '@prisma/client'
-import { type ActivityImportInput } from '#app/utils/activity-import.server.ts'
+import {
+	autoMatchImport,
+	createActivityImport,
+	type ActivityImportInput,
+} from '#app/utils/activity-import.server.ts'
 import { stravaApiGet } from './client.server.ts'
 import { stravaTypeToDiscipline } from './discipline-map.ts'
 import { createRateLimiter, STRAVA_RATE_LIMIT } from './rate-limit.ts'
@@ -60,6 +64,60 @@ export function mapActivityToImportInput(
 		polyline: activity.map?.summary_polyline ?? null,
 		rawJson: JSON.stringify(activity),
 	}
+}
+
+/**
+ * File a batch of fetched activities as `ActivityImport` rows and auto-match
+ * each modeled-discipline import to an existing planned session — the pipeline
+ * shared by manual sync (#72) and the reconciliation poll (#77). Both link to
+ * existing sessions only; auto-creating recording-only sessions is backfill's
+ * (#74) job alone.
+ *
+ * Idempotent: a duplicate hits the unique `(provider, externalId)` guard and is
+ * counted as `skipped` rather than re-imported. `'other'` imports (ADR 0015) are
+ * excluded from auto-match and wait in the inbox. `latestActivityAt` is the most
+ * recent activity start time seen, for callers that advance a watermark.
+ */
+export async function fileActivitiesWithAutoMatch(
+	athleteId: string,
+	activities: StravaActivity[],
+	timezone: string,
+): Promise<{
+	created: number
+	skipped: number
+	latestActivityAt: Date | null
+}> {
+	let created = 0
+	let skipped = 0
+	let latestActivityAt: Date | null = null
+
+	for (const activity of activities) {
+		const input = mapActivityToImportInput(activity)
+		if (latestActivityAt == null || input.startedAt > latestActivityAt) {
+			latestActivityAt = input.startedAt
+		}
+
+		let importId: string
+		try {
+			importId = (await createActivityImport(athleteId, input)).id
+		} catch (err) {
+			if (
+				err instanceof Error &&
+				err.message.toLowerCase().includes('unique')
+			) {
+				skipped++
+				continue
+			}
+			throw err
+		}
+		created++
+
+		if (input.discipline !== 'other') {
+			await autoMatchImport(athleteId, importId, timezone)
+		}
+	}
+
+	return { created, skipped, latestActivityAt }
 }
 
 type ConnectionRef = Pick<

--- a/app/integrations/strava/reconcile.server.test.ts
+++ b/app/integrations/strava/reconcile.server.test.ts
@@ -1,0 +1,259 @@
+import { invariant } from '@epic-web/invariant'
+import { faker } from '@faker-js/faker'
+import { http, HttpResponse } from 'msw'
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { createUser } from '#tests/db-utils.ts'
+import { server } from '#tests/mocks/index.ts'
+import {
+	enqueueReconciliationJobs,
+	RECONCILE_OVERLAP_MS,
+	runStravaReconciliation,
+	STRAVA_RECONCILE_JOB_KIND,
+} from './reconcile.server.ts'
+
+const ACTIVITIES_URL = 'https://www.strava.com/api/v3/athlete/activities'
+
+async function setupConnection(
+	overrides: Partial<{
+		status: string
+		lastSyncedAt: Date | null
+	}> = {},
+) {
+	const user = await prisma.user.create({
+		data: { ...createUser() },
+		select: { id: true },
+	})
+	const connection = await prisma.accountConnection.create({
+		data: {
+			athleteId: user.id,
+			provider: 'strava',
+			externalAthleteId: '12345678',
+			accessToken: 'initial_access',
+			refreshToken: 'initial_refresh',
+			expiresAt: new Date(Date.now() + 6 * 60 * 60 * 1000),
+			status: overrides.status ?? 'active',
+			connectedAt: new Date('2026-05-01T00:00:00.000Z'),
+			lastSyncedAt:
+				overrides.lastSyncedAt === undefined
+					? new Date('2026-05-20T00:00:00.000Z')
+					: overrides.lastSyncedAt,
+		},
+	})
+	return { user, connection }
+}
+
+/** A single Strava activity the webhook missed, returned by the mock feed. */
+function missedActivity(id = 5001) {
+	return {
+		id,
+		name: 'Missed Morning Run',
+		sport_type: 'Run',
+		type: 'Run',
+		distance: 10000,
+		moving_time: 3000,
+		elapsed_time: 3100,
+		start_date: '2026-05-21T06:00:00Z',
+		average_heartrate: 150,
+		map: { summary_polyline: 'abc' },
+	}
+}
+
+test('repairs a missed activity by filing it as an ActivityImport', async () => {
+	const { user } = await setupConnection()
+	server.use(
+		http.get(ACTIVITIES_URL, () => HttpResponse.json([missedActivity()])),
+	)
+
+	const result = await runStravaReconciliation(user.id)
+
+	invariant(result.ok, 'expected a successful reconciliation')
+	expect(result.created).toBe(1)
+
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(1)
+	expect(imports[0]!.externalId).toBe('5001')
+	expect(imports[0]!.externalProvider).toBe('strava')
+})
+
+test('fetches with a 48h overlap before lastSyncedAt to catch late edits', async () => {
+	const lastSyncedAt = new Date('2026-05-20T00:00:00.000Z')
+	const { user } = await setupConnection({ lastSyncedAt })
+
+	let after: string | null = null
+	server.use(
+		http.get(ACTIVITIES_URL, ({ request }) => {
+			after = new URL(request.url).searchParams.get('after')
+			// An activity that landed just before the watermark — a manual sync
+			// (no overlap) would never reach back for it.
+			return HttpResponse.json([
+				{
+					...missedActivity(5002),
+					start_date: '2026-05-19T06:00:00Z',
+				},
+			])
+		}),
+	)
+
+	const result = await runStravaReconciliation(user.id)
+
+	invariant(result.ok, 'expected a successful reconciliation')
+	const expectedAfter = Math.floor(
+		(lastSyncedAt.getTime() - RECONCILE_OVERLAP_MS) / 1000,
+	)
+	expect(after).toBe(String(expectedAfter))
+
+	const imported = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, externalId: '5002' },
+	})
+	expect(imported).not.toBeNull()
+})
+
+test('re-runs are idempotent: duplicates are skipped, not re-imported', async () => {
+	const { user } = await setupConnection()
+	server.use(
+		http.get(ACTIVITIES_URL, () => HttpResponse.json([missedActivity()])),
+	)
+
+	const first = await runStravaReconciliation(user.id)
+	const second = await runStravaReconciliation(user.id)
+
+	invariant(first.ok && second.ok, 'expected both runs to succeed')
+	expect(first.created).toBe(1)
+	expect(second.created).toBe(0)
+	expect(second.skipped).toBe(1)
+
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(1)
+})
+
+test('advances lastSyncedAt to the latest activity time on success', async () => {
+	const { user, connection } = await setupConnection({
+		lastSyncedAt: new Date('2026-05-20T00:00:00.000Z'),
+	})
+	server.use(
+		http.get(ACTIVITIES_URL, () =>
+			HttpResponse.json([
+				{ ...missedActivity(6001), start_date: '2026-05-21T06:00:00Z' },
+				{ ...missedActivity(6002), start_date: '2026-05-23T18:00:00Z' },
+			]),
+		),
+	)
+
+	await runStravaReconciliation(user.id)
+
+	const after = await prisma.accountConnection.findUnique({
+		where: { id: connection.id },
+	})
+	expect(after!.lastSyncedAt?.toISOString()).toBe('2026-05-23T18:00:00.000Z')
+})
+
+test('never regresses lastSyncedAt when the overlap only returns older activities', async () => {
+	const lastSyncedAt = new Date('2026-05-25T00:00:00.000Z')
+	const { user, connection } = await setupConnection({ lastSyncedAt })
+	// The 48h overlap reaches back before the watermark; the only activity it
+	// finds is older than lastSyncedAt and must not pull the watermark backward.
+	server.use(
+		http.get(ACTIVITIES_URL, () =>
+			HttpResponse.json([
+				{ ...missedActivity(6003), start_date: '2026-05-24T06:00:00Z' },
+			]),
+		),
+	)
+
+	await runStravaReconciliation(user.id)
+
+	const after = await prisma.accountConnection.findUnique({
+		where: { id: connection.id },
+	})
+	expect(after!.lastSyncedAt?.toISOString()).toBe(lastSyncedAt.toISOString())
+})
+
+test('auto-matches a modeled discipline but leaves "other" in the inbox', async () => {
+	const { user } = await setupConnection()
+	const workout = await prisma.workout.create({
+		select: { id: true },
+		data: {
+			title: faker.lorem.words(3),
+			discipline: 'run',
+			intent: 'endurance',
+			ownerId: user.id,
+		},
+	})
+	// Planned run on the same UTC day as the recovered run activity.
+	await prisma.workoutSession.create({
+		data: {
+			userId: user.id,
+			workoutId: workout.id,
+			scheduledAt: new Date('2026-05-21T09:00:00.000Z'),
+		},
+	})
+	server.use(
+		http.get(ACTIVITIES_URL, () =>
+			HttpResponse.json([
+				{ ...missedActivity(7001), sport_type: 'Run', type: 'Run' },
+				{
+					...missedActivity(7002),
+					sport_type: 'Hike',
+					type: 'Hike',
+					map: undefined,
+				},
+			]),
+		),
+	)
+
+	await runStravaReconciliation(user.id)
+
+	const run = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, externalId: '7001' },
+	})
+	expect(run!.promotedSessionId).not.toBeNull()
+
+	const other = await prisma.activityImport.findFirst({
+		where: { athleteId: user.id, externalId: '7002' },
+	})
+	expect(other!.discipline).toBe('other')
+	expect(other!.promotedSessionId).toBeNull()
+})
+
+test('enqueues one reconciliation job per active connection, skipping the rest', async () => {
+	const active1 = await setupConnection({ status: 'active' })
+	const active2 = await setupConnection({ status: 'active' })
+	await setupConnection({ status: 'revoked' })
+	await setupConnection({ status: 'error' })
+	await setupConnection({ status: 'expired' })
+
+	const result = await enqueueReconciliationJobs()
+
+	expect(result.enqueued).toBe(2)
+
+	const jobs = await prisma.job.findMany({
+		where: { kind: STRAVA_RECONCILE_JOB_KIND },
+	})
+	expect(jobs).toHaveLength(2)
+	const enqueuedAthleteIds = jobs
+		.map((j) => (JSON.parse(j.payload) as { athleteId: string }).athleteId)
+		.sort()
+	expect(enqueuedAthleteIds).toEqual([active1.user.id, active2.user.id].sort())
+})
+
+test('does not poll a connection that is no longer active', async () => {
+	// Revoked between dispatch and processing: the handler must no-op rather than
+	// fetch against a dead grant.
+	const { user } = await setupConnection({ status: 'revoked' })
+	server.use(
+		http.get(ACTIVITIES_URL, () => HttpResponse.json([missedActivity()])),
+	)
+
+	const result = await runStravaReconciliation(user.id)
+
+	expect(result).toEqual({ ok: false, reason: 'inactive' })
+	const imports = await prisma.activityImport.findMany({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toHaveLength(0)
+})

--- a/app/integrations/strava/reconcile.server.ts
+++ b/app/integrations/strava/reconcile.server.ts
@@ -1,0 +1,131 @@
+import { prisma } from '#app/utils/db.server.ts'
+import { enqueueJob } from '#app/utils/jobs/queue.server.ts'
+import {
+	fetchStravaActivitiesAfter,
+	fileActivitiesWithAutoMatch,
+} from './ingest.server.ts'
+import { STRAVA_PROVIDER } from './types.ts'
+
+/**
+ * Reconciliation poll (#77, ADR 0013) — the safety net under the webhook. A
+ * daily sweep re-fetches each active Account Connection's recent Strava
+ * activities and files any the webhook (#76) dropped during downtime or that
+ * Strava retried-and-gave-up on. It reuses the same fetch path and idempotent
+ * `(provider, externalId)` guard as manual sync and backfill.
+ */
+
+/**
+ * How far before `lastSyncedAt` reconciliation reaches when fetching. The
+ * overlap catches late edits and events that landed just before the watermark
+ * advanced but were never recorded.
+ */
+export const RECONCILE_OVERLAP_MS = 48 * 60 * 60 * 1000
+
+/** The `kind` registered against the job queue for reconciliation jobs. */
+export const STRAVA_RECONCILE_JOB_KIND = 'strava-reconcile'
+
+/** Default reconciliation cadence — daily (ADR 0013; a tuning knob). */
+const DEFAULT_RECONCILE_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The daily sweep dispatcher (#77). Enqueues one reconciliation job per *active*
+ * Strava Account Connection — non-active connections (`revoked`, `error`,
+ * `expired`) are deliberately not polled. Each job is processed out of band by
+ * the single worker, so a fleet-wide sweep queues behind itself rather than
+ * hammering Strava's per-app rate budget all at once.
+ */
+export async function enqueueReconciliationJobs(): Promise<{
+	enqueued: number
+}> {
+	const connections = await prisma.accountConnection.findMany({
+		where: { provider: STRAVA_PROVIDER, status: 'active' },
+		select: { athleteId: true },
+	})
+
+	for (const { athleteId } of connections) {
+		await enqueueJob({
+			kind: STRAVA_RECONCILE_JOB_KIND,
+			payload: { athleteId },
+		})
+	}
+
+	return { enqueued: connections.length }
+}
+
+export type StravaReconcileResult =
+	| { ok: true; created: number; skipped: number }
+	| { ok: false; reason: 'not-connected' | 'inactive' }
+
+export async function runStravaReconciliation(
+	athleteId: string,
+): Promise<StravaReconcileResult> {
+	const connection = await prisma.accountConnection.findUnique({
+		where: { athleteId_provider: { athleteId, provider: STRAVA_PROVIDER } },
+	})
+	if (!connection) return { ok: false, reason: 'not-connected' }
+	if (connection.status !== 'active') return { ok: false, reason: 'inactive' }
+
+	const since = connection.lastSyncedAt ?? connection.connectedAt
+	const after = Math.floor((since.getTime() - RECONCILE_OVERLAP_MS) / 1000)
+
+	const timezone =
+		(
+			await prisma.athleteProfile.findUnique({
+				where: { userId: athleteId },
+				select: { timezone: true },
+			})
+		)?.timezone ?? 'UTC'
+
+	const activities = await fetchStravaActivitiesAfter(connection, after)
+	const { created, skipped, latestActivityAt } =
+		await fileActivitiesWithAutoMatch(athleteId, activities, timezone)
+
+	// Advance the watermark forward-only: the 48h overlap reaches back before
+	// `lastSyncedAt`, so a sweep that only finds older activities must not pull it
+	// backward. No activities at all leaves it untouched.
+	const current = connection.lastSyncedAt
+	if (
+		latestActivityAt != null &&
+		(current == null || latestActivityAt > current)
+	) {
+		await prisma.accountConnection.update({
+			where: { id: connection.id },
+			data: { lastSyncedAt: latestActivityAt },
+		})
+	}
+
+	return { ok: true, created, skipped }
+}
+
+/**
+ * Start the daily reconciliation sweep (#77, ADR 0013). Mirrors the job worker:
+ * a single `unref`'d interval so it never keeps the process alive, returning a
+ * stop function for graceful shutdown. Each tick enqueues one job per active
+ * connection; the single worker drains them within the rate budget. The first
+ * sweep runs after one interval, not on boot, so frequent restarts don't trigger
+ * repeated fleet-wide polls.
+ *
+ * In-process scheduling is the minimum-viable shape for a single-process deploy;
+ * BullMQ repeatable jobs or Fly Machines schedules remain the documented escape
+ * hatch if cadence or fan-out ever outgrows it.
+ */
+export function startReconciliationSchedule({
+	intervalMs = DEFAULT_RECONCILE_INTERVAL_MS,
+}: { intervalMs?: number } = {}): () => void {
+	let running = false
+
+	const timer = setInterval(() => {
+		if (running) return
+		running = true
+		void enqueueReconciliationJobs()
+			.catch((error) => {
+				console.error('[reconciliation] sweep failed to enqueue', error)
+			})
+			.finally(() => {
+				running = false
+			})
+	}, intervalMs)
+	if (typeof timer.unref === 'function') timer.unref()
+
+	return () => clearInterval(timer)
+}

--- a/app/integrations/strava/sync.server.ts
+++ b/app/integrations/strava/sync.server.ts
@@ -1,12 +1,8 @@
-import {
-	autoMatchImport,
-	createActivityImport,
-} from '#app/utils/activity-import.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { StravaConnectionRevokedError } from './client.server.ts'
 import {
 	fetchStravaActivitiesAfter,
-	mapActivityToImportInput,
+	fileActivitiesWithAutoMatch,
 } from './ingest.server.ts'
 import { STRAVA_PROVIDER } from './types.ts'
 
@@ -61,27 +57,11 @@ export async function syncStravaActivities(
 		throw err
 	}
 
-	let created = 0
-	let skipped = 0
-	for (const activity of activities) {
-		const input = mapActivityToImportInput(activity)
-		let importId: string
-		try {
-			importId = (await createActivityImport(athleteId, input)).id
-		} catch (err) {
-			if (err instanceof Error && err.message.toLowerCase().includes('unique')) {
-				skipped++
-				continue
-			}
-			throw err
-		}
-		created++
-		// 'other' imports are excluded from auto-match (ADR 0015); they wait in the
-		// inbox for the athlete to handle manually.
-		if (input.discipline !== 'other') {
-			await autoMatchImport(athleteId, importId, timezone)
-		}
-	}
+	const { created, skipped } = await fileActivitiesWithAutoMatch(
+		athleteId,
+		activities,
+		timezone,
+	)
 
 	// Only advance the watermark on a fully successful pass.
 	await prisma.accountConnection.update({

--- a/app/utils/jobs/handlers.server.test.ts
+++ b/app/utils/jobs/handlers.server.test.ts
@@ -44,3 +44,21 @@ test('processing a strava-backfill job runs the backfill end-to-end', async () =
 	const row = await prisma.job.findUniqueOrThrow({ where: { id: job.id } })
 	expect(row.status).toBe('completed')
 })
+
+test('processing a strava-reconcile job runs reconciliation end-to-end', async () => {
+	const user = await setupConnectedAthlete()
+	const job = await enqueueJob({
+		kind: 'strava-reconcile',
+		payload: { athleteId: user.id },
+	})
+
+	const result = await processNextJob(jobHandlers)
+
+	expect(result).toBe('processed')
+	const imports = await prisma.activityImport.count({
+		where: { athleteId: user.id },
+	})
+	expect(imports).toBe(4)
+	const row = await prisma.job.findUniqueOrThrow({ where: { id: job.id } })
+	expect(row.status).toBe('completed')
+})

--- a/app/utils/jobs/handlers.server.ts
+++ b/app/utils/jobs/handlers.server.ts
@@ -1,5 +1,9 @@
 import { runStravaBackfill } from '#app/integrations/strava/backfill.server.ts'
 import {
+	runStravaReconciliation,
+	STRAVA_RECONCILE_JOB_KIND,
+} from '#app/integrations/strava/reconcile.server.ts'
+import {
 	parseWebhookJobPayload,
 	processStravaWebhookEvent,
 	STRAVA_WEBHOOK_JOB_KIND,
@@ -26,5 +30,17 @@ export const jobHandlers: JobHandlers = {
 		// A missing Account Connection or a revoked grant is a deliberate no-op
 		// inside the processor — only genuine fetch/DB errors throw and retry.
 		await processStravaWebhookEvent(parseWebhookJobPayload(payload))
+	},
+	[STRAVA_RECONCILE_JOB_KIND]: async (payload) => {
+		const athleteId = payload.athleteId
+		if (typeof athleteId !== 'string') {
+			throw new Error(
+				'strava-reconcile job requires a string athleteId payload',
+			)
+		}
+		// `not-connected` / `inactive` are deliberate outcomes, not failures: a
+		// connection that was revoked between dispatch and processing is simply not
+		// polled. Only genuine fetch/DB errors throw and trigger retry.
+		await runStravaReconciliation(athleteId)
 	},
 }

--- a/docs/adr/0013-strava-trigger-model.md
+++ b/docs/adr/0013-strava-trigger-model.md
@@ -105,3 +105,34 @@ ADR committed to, so the implementation choice is recorded here.
   latest activity and `backfillCompletedAt` on success, and recomputes Training
   Load across the window. Retries converge: an import left unpromoted by an
   interrupted run is promoted on the next attempt.
+
+## Amendment (#77): reconciliation poll trigger and behaviour
+
+The reconciliation sweep this ADR committed to is implemented as the third
+trigger feeding the same queue and pipeline.
+
+- **In-process daily schedule.** A single `unref`'d interval started from the
+  entry server (`startReconciliationSchedule`, next to `startJobWorker`) fires
+  daily and enqueues one `strava-reconcile` job per `status: 'active'` Account
+  Connection. The cadence is the tuning knob this ADR anticipated. Consistent
+  with the queue-technology amendment (#74), this is the minimum-viable shape
+  for a single-process deploy; BullMQ repeatable jobs or Fly Machines schedules
+  remain the documented escape hatch. The first sweep runs after one interval
+  (not on boot) so frequent restarts don't trigger repeated fleet-wide polls.
+- **Non-active connections are not polled.** Only `active` connections are
+  dispatched; `revoked`, `error`, and `expired` are skipped. The per-connection
+  handler re-checks status, so a connection revoked between dispatch and
+  processing is a deliberate no-op rather than a fetch against a dead grant.
+- **48h overlap window.** Each job fetches activities since `lastSyncedAt - 48h`
+  so late edits and events that landed just before the watermark advanced are
+  still caught. Deduplication relies on the unique `(provider, externalId)`
+  guard — duplicate inserts are no-ops, so re-runs never double-import.
+- **Forward-only watermark.** `lastSyncedAt` advances to the latest fetched
+  activity time but never regresses (the overlap reaches back before the
+  watermark); a sweep that finds only older activities leaves it untouched.
+- **Auto-match, not auto-create.** Reconciliation links new imports to existing
+  planned sessions (the manual-sync / webhook-`create` behaviour) and never
+  auto-creates recording-only sessions — that asymmetry is backfill's alone.
+  `'other'` imports (ADR 0015) wait in the inbox. Because every
+  `createActivityImport` publishes to the Live Imports Stream (#75), recovered
+  activities surface live without extra wiring.

--- a/server/index.ts
+++ b/server/index.ts
@@ -234,12 +234,19 @@ ${styleText('bold', 'Press Ctrl+C to stop')}
 })
 
 // Start the in-process job worker that drains the queue (Strava backfill #74,
-// and future webhook/reconciliation jobs). Imported dynamically so it only
-// loads once the server is actually running.
+// webhook #76, reconciliation #77). Imported dynamically so it only loads once
+// the server is actually running.
 const { startJobWorker } = await import('#app/utils/jobs/worker.server.ts')
 const stopJobWorker = startJobWorker()
 
+// Start the daily reconciliation sweep (#77) that enqueues a poll job per active
+// Account Connection, catching any activities the webhook (#76) missed.
+const { startReconciliationSchedule } =
+	await import('#app/integrations/strava/reconcile.server.ts')
+const stopReconciliationSchedule = startReconciliationSchedule()
+
 closeWithGrace(async ({ err }) => {
+	stopReconciliationSchedule()
 	stopJobWorker()
 	await new Promise((resolve, reject) => {
 		server.close((e) => (e ? reject(e) : resolve('ok')))


### PR DESCRIPTION
Implements the daily reconciliation sweep that serves as a safety net under the webhook, catching any activities Strava failed to deliver during downtime or retries.

## Summary

This PR adds the reconciliation trigger (#77) committed to in ADR 0013. The implementation includes:

- **Daily in-process schedule** (`startReconciliationSchedule`): An `unref`'d interval that fires daily and enqueues one `strava-reconcile` job per active Account Connection. The first sweep runs after one interval (not on boot) to avoid repeated polls on frequent restarts.
- **Per-connection reconciliation handler** (`runStravaReconciliation`): Fetches activities since `lastSyncedAt - 48h` (the overlap window catches late edits), files them as `ActivityImport` rows via the shared pipeline, and advances the watermark forward-only.
- **Shared filing pipeline** (`fileActivitiesWithAutoMatch`): Extracted from manual sync to deduplicate logic. Idempotent via the unique `(provider, externalId)` guard; auto-matches modeled disciplines to existing sessions but leaves `'other'` imports in the inbox.
- **Job handler integration**: Wired into the job worker so reconciliation jobs are processed out of band alongside backfill and webhook events.
- **Non-active connection safety**: Only `active` connections are dispatched; `revoked`, `error`, and `expired` are skipped. The handler re-checks status, so a connection revoked between dispatch and processing is a deliberate no-op.

The reconciliation poll reuses the same fetch path and idempotent deduplication as manual sync and backfill, ensuring consistency across all three triggers feeding the activity import pipeline.

## Test Plan

Added comprehensive test suite (`reconcile.server.test.ts`) covering:
- Basic missed activity recovery and filing as `ActivityImport`
- 48h overlap window behavior and watermark advancement
- Idempotency: re-runs skip duplicates rather than re-importing
- Forward-only watermark: never regresses when overlap finds older activities
- Auto-match behavior: modeled disciplines linked to existing sessions, `'other'` left in inbox
- Job enqueueing: only active connections dispatched, non-active skipped
- Connection status safety: revoked connections are not polled

Added integration test in `handlers.server.test.ts` verifying end-to-end job processing.

## Checklist

- [x] Tests updated
- [x] Docs updated (ADR 0013 amendment)

https://claude.ai/code/session_01YB3jW7T39r9MqfAThuhcHM