### PR TITLE
feat: migrate training/sessions.new native selects to shadcn Select (#80)

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -1,6 +1,7 @@
-import { useInputControl } from '@conform-to/react'
+import { type FieldMetadata, useInputControl } from '@conform-to/react'
 import { REGEXP_ONLY_DIGITS_AND_CHARS, type OTPInputProps } from 'input-otp'
 import React, { useId } from 'react'
+import { cn } from '#app/utils/misc.tsx'
 import { Checkbox, type CheckboxProps } from './ui/checkbox.tsx'
 import {
 	Field as FormField,
@@ -16,6 +17,13 @@ import {
 	InputOTPSlot,
 } from './ui/input-otp.tsx'
 import { Input } from './ui/input.tsx'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from './ui/select.tsx'
 import { Textarea } from './ui/textarea.tsx'
 
 export type ListOfErrors = Array<string | null | undefined> | null | undefined
@@ -101,6 +109,70 @@ export function Field({
 				</FieldContent>
 			</FormField>
 		</FieldGroup>
+	)
+}
+
+export function SelectField({
+	meta,
+	labelProps,
+	items,
+	placeholder,
+	size = 'default',
+	triggerClassName,
+	className,
+	errors,
+}: {
+	meta: FieldMetadata<string>
+	labelProps: { children: React.ReactNode; className?: string }
+	items: Array<{ value: string; label: React.ReactNode }>
+	placeholder?: string
+	size?: 'sm' | 'default'
+	triggerClassName?: string
+	className?: string
+	errors?: ListOfErrors
+}) {
+	const control = useInputControl({
+		key: meta.key,
+		name: meta.name,
+		formId: meta.formId,
+		initialValue: meta.initialValue,
+	})
+	const fallbackId = useId()
+	const id = meta.id ?? fallbackId
+	const fieldErrors = errors ?? (meta.errors as ListOfErrors)
+	const errorsToRender = getErrorsToRender(fieldErrors)
+	const errorId = errorsToRender.length ? `${id}-error` : undefined
+
+	return (
+		<div className={cn('space-y-2', className)}>
+			<label htmlFor={id} className={labelProps.className}>
+				{labelProps.children}
+			</label>
+			<Select
+				value={control.value ?? ''}
+				onValueChange={(value) => control.change((value as string) ?? '')}
+			>
+				<SelectTrigger
+					id={id}
+					size={size}
+					className={cn('w-full', triggerClassName)}
+					aria-invalid={errorId ? true : undefined}
+					aria-describedby={errorId}
+					onFocus={() => control.focus()}
+					onBlur={() => control.blur()}
+				>
+					<SelectValue placeholder={placeholder} />
+				</SelectTrigger>
+				<SelectContent>
+					{items.map((item) => (
+						<SelectItem key={item.value} value={item.value}>
+							{item.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			<ErrorList id={errorId} errors={errorsToRender} />
+		</div>
 	)
 }
 

--- a/app/routes/training/sessions.new.route.test.tsx
+++ b/app/routes/training/sessions.new.route.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { createRoutesStub } from 'react-router'
+import { expect, test, vi } from 'vitest'
+import NewSessionRoute from './sessions.new.tsx'
+
+function renderNewSession() {
+	const submitted = vi.fn()
+	const App = createRoutesStub([
+		{
+			path: '/training/sessions/new',
+			Component: (props: Record<string, unknown>) => (
+				<NewSessionRoute {...(props as any)} />
+			),
+			loader: () => ({
+				defaultDate: '2026-06-01',
+				defaultTime: '08:00',
+				exercises: [],
+				disciplineProfiles: [],
+			}),
+			action: async ({ request }) => {
+				const formData = await request.formData()
+				submitted(Object.fromEntries(formData))
+				return { result: null }
+			},
+			HydrateFallback: () => <div>Loading...</div>,
+		},
+	])
+	render(<App initialEntries={['/training/sessions/new']} />)
+	return { submitted }
+}
+
+test('submits the intent chosen via the Select', async () => {
+	const user = userEvent.setup()
+	const { submitted } = renderNewSession()
+
+	await user.type(await screen.findByLabelText(/title/i), 'Tempo Run')
+
+	await user.click(screen.getByLabelText(/intent/i))
+	await user.click(await screen.findByRole('option', { name: 'Tempo' }))
+
+	await user.click(screen.getByRole('button', { name: /create session/i }))
+
+	await waitFor(() => expect(submitted).toHaveBeenCalledTimes(1))
+	expect(submitted.mock.calls[0]![0].intent).toBe('tempo')
+})
+
+test('submits the discipline chosen via the Select', async () => {
+	const user = userEvent.setup()
+	const { submitted } = renderNewSession()
+
+	await user.type(await screen.findByLabelText(/title/i), 'Open Water Swim')
+
+	// The top-level workout Discipline select (the per-step discipline field,
+	// migrated separately, shares the label so we take the first match).
+	await user.click(screen.getAllByLabelText('Discipline')[0]!)
+	const listbox = await screen.findByRole('listbox')
+	await user.click(within(listbox).getByRole('option', { name: /swim/i }))
+
+	await user.click(screen.getByRole('button', { name: /create session/i }))
+
+	await waitFor(() => expect(submitted).toHaveBeenCalledTimes(1))
+	expect(submitted.mock.calls[0]![0].discipline).toBe('swim')
+})
+
+test('changing a step Kind reactively swaps in the matching fields', async () => {
+	const user = userEvent.setup()
+	renderNewSession()
+
+	await screen.findByLabelText(/title/i) // wait for hydration
+
+	// Cardio is the default kind, so the per-step Discipline field is rendered
+	// alongside the top-level workout Discipline (two matches).
+	expect(screen.getAllByLabelText('Discipline')).toHaveLength(2)
+
+	await user.click(screen.getByLabelText(/kind/i))
+	const listbox = await screen.findByRole('listbox')
+	await user.click(within(listbox).getByRole('option', { name: 'Rest' }))
+
+	// Rest fields have no Discipline select, so only the top-level one survives.
+	await waitFor(() =>
+		expect(screen.getAllByLabelText('Discipline')).toHaveLength(1),
+	)
+})

--- a/app/routes/training/sessions.new.tsx
+++ b/app/routes/training/sessions.new.tsx
@@ -1,8 +1,8 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { getZodConstraint, parseWithZod } from '@conform-to/zod'
 import { data, Form, Link, redirect } from 'react-router'
-import { ErrorList, Field } from '#app/components/forms.tsx'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import { ErrorList, Field, SelectField } from '#app/components/forms.tsx'
 import { Button, buttonVariants } from '#app/components/ui/button.tsx'
 import {
 	Card,
@@ -10,8 +10,8 @@ import {
 	CardHeader,
 	CardTitle,
 } from '#app/components/ui/card.tsx'
-import { requireUserId } from '#app/utils/auth.server.ts'
 import { getOrCreateAthleteProfile } from '#app/utils/athlete.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
 import { getDisciplineLabel } from '#app/utils/training.ts'
 import {
 	DISCIPLINES,
@@ -25,6 +25,7 @@ import {
 	createWorkoutSession,
 	getExerciseCatalog,
 } from '#app/utils/workout.server.ts'
+import { type Route } from './+types/sessions.new.ts'
 import {
 	buildStepInput,
 	CardioStepFields,
@@ -33,10 +34,8 @@ import {
 	FormSchema,
 	RestStepFields,
 	STEP_KIND_LABELS,
-	STEP_SELECT_CLASS,
 	StrengthStepFields,
 } from './__workout-step-fields.tsx'
-import { type Route } from './+types/sessions.new.ts'
 
 export const meta: Route.MetaFunction = () => [
 	{ title: 'New Workout Session | Trainm8' },
@@ -173,49 +172,31 @@ export default function NewSessionRoute({
 								errors={fields.title.errors as string[] | undefined}
 							/>
 
-							<div className="space-y-2">
-								<label
-									htmlFor={fields.discipline.id}
-									className="text-body-xs text-muted-foreground font-medium"
-								>
-									Discipline
-								</label>
-								<select
-									{...getInputProps(fields.discipline, { type: 'text' })}
-									className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-								>
-									{DISCIPLINES.map((type) => (
-										<option key={type} value={type}>
-											{getDisciplineLabel(type)}
-										</option>
-									))}
-								</select>
-								<ErrorList
-									errors={fields.discipline.errors as string[] | undefined}
-								/>
-							</div>
+							<SelectField
+								meta={fields.discipline}
+								labelProps={{
+									children: 'Discipline',
+									className: 'text-body-xs text-muted-foreground font-medium',
+								}}
+								items={DISCIPLINES.map((type) => ({
+									value: type,
+									label: getDisciplineLabel(type),
+								}))}
+								errors={fields.discipline.errors as string[] | undefined}
+							/>
 
-							<div className="space-y-2">
-								<label
-									htmlFor={fields.intent.id}
-									className="text-body-xs text-muted-foreground font-medium"
-								>
-									Intent
-								</label>
-								<select
-									{...getInputProps(fields.intent, { type: 'text' })}
-									className="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-								>
-									{WORKOUT_INTENTS.map((value) => (
-										<option key={value} value={value}>
-											{INTENT_LABELS[value]}
-										</option>
-									))}
-								</select>
-								<ErrorList
-									errors={fields.intent.errors as string[] | undefined}
-								/>
-							</div>
+							<SelectField
+								meta={fields.intent}
+								labelProps={{
+									children: 'Intent',
+									className: 'text-body-xs text-muted-foreground font-medium',
+								}}
+								items={WORKOUT_INTENTS.map((value) => ({
+									value,
+									label: INTENT_LABELS[value],
+								}))}
+								errors={fields.intent.errors as string[] | undefined}
+							/>
 
 							<div className="grid grid-cols-2 gap-4">
 								<Field
@@ -343,26 +324,21 @@ export default function NewSessionRoute({
 																Step {stepIndex + 1}
 															</legend>
 															<div className="space-y-3">
-																<div className="space-y-1">
-																	<label
-																		htmlFor={sf.kind.id}
-																		className="text-body-2xs text-muted-foreground font-medium"
-																	>
-																		Kind
-																	</label>
-																	<select
-																		{...getInputProps(sf.kind, {
-																			type: 'text',
-																		})}
-																		className={STEP_SELECT_CLASS}
-																	>
-																		{STEP_KINDS.map((k) => (
-																			<option key={k} value={k}>
-																				{STEP_KIND_LABELS[k]}
-																			</option>
-																		))}
-																	</select>
-																</div>
+																<SelectField
+																	meta={sf.kind}
+																	labelProps={{
+																		children: 'Kind',
+																		className:
+																			'text-body-2xs text-muted-foreground font-medium',
+																	}}
+																	items={STEP_KINDS.map((k) => ({
+																		value: k,
+																		label: STEP_KIND_LABELS[k],
+																	}))}
+																	errors={
+																		sf.kind.errors as string[] | undefined
+																	}
+																/>
 
 																{currentKind === 'cardio' ? (
 																	<CardioStepFields


### PR DESCRIPTION
Replace the three native <select> elements (Discipline, Intent, step
Kind) in routes/training/sessions.new.tsx with the shadcn Select
primitive added in #79. Adds a reusable SelectField wrapper to
forms.tsx that wires base-ui Select into Conform via useInputControl
(mirroring the existing CheckboxField), so field state, aria-invalid
validation styling, and the reactive value that drives conditional
step rendering all keep working.

The inline border-input cluster is gone and the step Kind no longer
uses STEP_SELECT_CLASS (the constant itself is removed in #81).

Adds a jsdom render test covering submission of the chosen
discipline/intent and reactive step-field switching on Kind change.